### PR TITLE
pyopengl2-63 benchmarking PVR and cache packing

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -25,13 +25,69 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="a3499ba1-dc0a-42c5-b463-7e2e3496ac29" name="pyopengl2-58 implement bffr cache compaction, merge algorithm" comment="pyopengl2-58 implement bffr cache compaction, merge algorithm&#10;&#10;benchmark index rendering&#10;    vocabulary:&#10;        array    : memory consecutive data&#10;        buffer   : array of GPU&#10;        subarray : consecutive sub data of an array that is not in use&#10;        block    : consecutive sub data in use&#10;        gap      : vacant subarray inbetween blocks&#10;        refilling: activity of filling gaps with blocks&#10;        tightly packed: array that has no subarray but only blocks&#10;    &#10;    about tightly packing array&#10;        ? Buffer that has no gap is beneficial as glDraw can look through only necessary data. On the other hand, buffer that has many gaps are inefficient as it has to look through all subarray that is not in use. So refilling seems to be beneficial at first glance, yet, it is not always true. For example, time used to refill can exceed time saved be rendering tightly packed buffer(or pushing tightly packed data into buffer).&#10;        ? refilling can be done by moving very last block into returned indices. But tight packing is not guaranteed with single filling operation. If size of a returned array is bigger then the last block, smaller gap will remain despite refilling.&#10;        ! Compromised can be made by simply refilling just once, despite possibly remaining gap. This way array is not guaranteed to be tightly packed, but has tendency of becoming tightly packed as returned block is always refilled with very last block thus back-padaling last index.&#10;        ! Refilling shouldnt be called automatically. For example if point vertex is moved to refill, index buffer block pointing at it looses correct index. Method caller has to handle this problem.&#10;        &#10;    about too many shattered subarray&#10;        ? It is bad to have too many shattered subarray. Just having it consumes memory(having one (0, 256) vs having 256 (0, 1), (1, 2)...). It can also slow down various functions that has to do something with a list of vacant subarrays.  &#10;        ! However, merging is automatically done throughout execution cycle. New block request always consumes vertex by front -&gt; back order. So even block pool is harshly shattered, newly created block tend to have consecutive indices(if it consumed more then one blocks from the pool). So, merging is executed when block is returned. By wrapping consecutive indices as single subarray and returning it.">
+      <change afterPath="$PROJECT_DIR$/etc/201224 test plane ray intersection.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/201227 vector from 2 points.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/201229 named vector.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/201229 pln function addition.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/bench/PRV vs consecutive index rendering.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/bench/PRVed vs shortened.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/bench/benchmark point consecutive indexing.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/bench/benchmark triangle consecutive indexing.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/bench/refilling analysis.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/casting dict to dict.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/default message decorator.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/descriptor.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/201230 line intersection test.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/201231 triangle intersection test.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/flat to vertical view.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/multiply transformation matrix to plane.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/test named vectors.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/test plane standarization.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/testing vector amplify.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gkernel/timing problem inbetween glfw callbak and draw thread.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gl/array nested array byte stream test.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gl/chained view.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gl/draw bonding.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gl/duplicate buffer push test.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gl/single buffer draw triangle.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gl/single frame triangle drawing with element array.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/gl/single frame triangle drawing.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/heap generator.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/inherit instance.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/init inherit.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/init none-ing.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/interface mechanism.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/isinstance check.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/memory firstfit alocating test.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/meta redirecting.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/noding/example.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/noding/getting explained.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/noding/refreshing.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/noding/setting explained.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/numpy/is column vector good.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/numpy/looking for correct struct.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/numpy/pointer slice.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/numpy/single structured array.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/numpy/store array into structured array.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/numpy/struct array apply tm bench.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/numpy/struct array self power bench.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/pipeline example.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/python/chained.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/python/new generator from used generator.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/python/singleton.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/ref or proxy.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/scrible.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/structured numpy array.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/transformatioin into array.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/view/main.py" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/etc/wrapper.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_Checkout_at_2020-08-06__10_58__Default_Changelist_.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_Checkout_at_2020-08-06__10_58__Default_Changelist_.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_Checkout_at_2020-08-17__1_35__Default_Changelist_.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_Checkout_at_2020-08-17__1_35__Default_Changelist_.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/run/render circle points.py" beforeDir="false" afterPath="$PROJECT_DIR$/run/render circle points.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/run/render points form.py" beforeDir="false" afterPath="$PROJECT_DIR$/run/render points form.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/ckernel/render_context/opengl_context/bffr_cache.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/ckernel/render_context/opengl_context/bffr_cache.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/ckernel/render_context/opengl_context/ogl_entities.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/ckernel/render_context/opengl_context/ogl_entities.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/global_tools/skip_list.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/global_tools/skip_list.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/mkernel/gkernel_wrapper.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/mkernel/gkernel_wrapper.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/mkernel/primitive_renderer.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/mkernel/primitive_renderer.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/wkernel/pipeline/nodes/opengl/primitive/buffer_nodes.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/wkernel/pipeline/nodes/opengl/primitive/buffer_nodes.py" afterDir="false" />
     </list>
     <list id="244346dc-c4b7-4080-9029-2152216f4b46" name="Default Changelist" comment="" />
     <list id="a2bb444d-d792-46e6-85ce-941cf08504b1" name="pyopengl2-19 mapping cursor pos into view coordinate system" comment="some refactoring before writing ray-traingle intersection" />
@@ -64,6 +120,7 @@
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+    <option name="RESET_MODE" value="HARD" />
     <option name="ROOT_SYNC" value="DONT_SYNC" />
   </component>
   <component name="GitSEFilterConfiguration">
@@ -91,29 +148,29 @@
     <property name="ToolWindowRun.ShowToolbar" value="false" />
     <property name="add_unversioned_files" value="true" />
     <property name="com.intellij.ide.scratch.LRUPopupBuilder$1/New Scratch File" value="Python" />
-    <property name="last_opened_file_path" value="$PROJECT_DIR$/examples/gl" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$/etc/bench" />
     <property name="settings.editor.selected.configurable" value="com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable" />
     <property name="start.from.branch" value="origin/pyopengl2-39" />
     <property name="tasks.open.task.update.state.enabled" value="true" />
   </component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
+      <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\etc\bench" />
       <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\examples\gl" />
       <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\src\mkernel\shaders" />
       <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\run" />
       <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\src\mkernel" />
-      <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\examples\numpy" />
     </key>
     <key name="MoveFile.RECENT_KEYS">
+      <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\etc\bench" />
+      <recent name="C:\Users\dingo\OneDrive\prgrm_dev\etc" />
       <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\src\ckernel\render_context\opengl_context\factories\prgrm" />
       <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\src\ckernel\render_context\opengl_context\factories" />
       <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\src\mkernel\shaders" />
-      <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\src\wkernel\devices\input" />
-      <recent name="C:\Users\dingo\OneDrive\prgrm_dev\pyopengl2\src\wkernel\devices\render" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.render points form">
-    <configuration name="render circle points" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+  <component name="RunManager" selected="Python.refilling analysis">
+    <configuration name="PRV vs consecutive index rendering (1)" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="pyopengl2" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -121,11 +178,11 @@
         <env name="PYTHONUNBUFFERED" value="1" />
       </envs>
       <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/run" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/etc/bench" />
       <option name="IS_MODULE_SDK" value="true" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/run/render circle points.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/etc/bench/PRV vs consecutive index rendering.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <option name="EMULATE_TERMINAL" value="false" />
@@ -134,7 +191,7 @@
       <option name="INPUT_FILE" value="" />
       <method v="2" />
     </configuration>
-    <configuration name="render lines with edge" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+    <configuration name="PRVed vs shortened" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="pyopengl2" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -142,11 +199,11 @@
         <env name="PYTHONUNBUFFERED" value="1" />
       </envs>
       <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/run" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/etc/bench" />
       <option name="IS_MODULE_SDK" value="true" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/run/render lines with edge.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/etc/bench/PRVed vs shortened.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <option name="EMULATE_TERMINAL" value="false" />
@@ -155,7 +212,7 @@
       <option name="INPUT_FILE" value="" />
       <method v="2" />
     </configuration>
-    <configuration name="render points form" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+    <configuration name="benchmark point consecutive indexing" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="pyopengl2" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -163,11 +220,11 @@
         <env name="PYTHONUNBUFFERED" value="1" />
       </envs>
       <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/run" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/etc/bench" />
       <option name="IS_MODULE_SDK" value="true" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/run/render points form.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/etc/bench/benchmark point consecutive indexing.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <option name="EMULATE_TERMINAL" value="false" />
@@ -176,7 +233,7 @@
       <option name="INPUT_FILE" value="" />
       <method v="2" />
     </configuration>
-    <configuration name="render rectangular points" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+    <configuration name="benchmark triangle consecutive indexing" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="pyopengl2" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -184,11 +241,11 @@
         <env name="PYTHONUNBUFFERED" value="1" />
       </envs>
       <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/run" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/etc/bench" />
       <option name="IS_MODULE_SDK" value="true" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/run/render rectangular points.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/etc/bench/benchmark triangle consecutive indexing.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <option name="EMULATE_TERMINAL" value="false" />
@@ -197,7 +254,7 @@
       <option name="INPUT_FILE" value="" />
       <method v="2" />
     </configuration>
-    <configuration name="render triangles with edge" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+    <configuration name="refilling analysis" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="pyopengl2" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
@@ -205,11 +262,11 @@
         <env name="PYTHONUNBUFFERED" value="1" />
       </envs>
       <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/run" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/etc/bench" />
       <option name="IS_MODULE_SDK" value="true" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/run/render triangles with edge.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/etc/bench/refilling analysis.py" />
       <option name="PARAMETERS" value="" />
       <option name="SHOW_COMMAND_LINE" value="false" />
       <option name="EMULATE_TERMINAL" value="false" />
@@ -220,11 +277,11 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Python.render points form" />
-        <item itemvalue="Python.render circle points" />
-        <item itemvalue="Python.render lines with edge" />
-        <item itemvalue="Python.render triangles with edge" />
-        <item itemvalue="Python.render rectangular points" />
+        <item itemvalue="Python.refilling analysis" />
+        <item itemvalue="Python.PRVed vs shortened" />
+        <item itemvalue="Python.PRV vs consecutive index rendering (1)" />
+        <item itemvalue="Python.benchmark point consecutive indexing" />
+        <item itemvalue="Python.benchmark triangle consecutive indexing" />
       </list>
     </recent_temporary>
   </component>

--- a/etc/201224 test plane ray intersection.py
+++ b/etc/201224 test plane ray intersection.py
@@ -1,0 +1,18 @@
+import mkernel.gkernel_wrapper as w
+import math
+
+
+p = w.Pln((0,0,0), (1,0,0), (0,1,0), (0,0,1))
+a = w.Pnt(0,0,0)
+b = w.Pnt(10,10,0)
+
+r = w.Ray((10,10,10), (0,0,-1))
+k= w.Pnt
+print(type(k(0,0,0)))
+# print(p.intersect(r))
+print(a, type(a))
+print(r, type(r))
+print(p, type(p))
+print(a)
+print(a.intersect(r))
+print(b.intersect(r))

--- a/etc/201227 vector from 2 points.py
+++ b/etc/201227 vector from 2 points.py
@@ -1,0 +1,6 @@
+from gkernel.dtype.geometric.primitive import Pnt, Vec
+
+a = Pnt(0,0,0)
+b = Pnt(10,10,10)
+print(a - b)
+print(b - a)

--- a/etc/201229 named vector.py
+++ b/etc/201229 named vector.py
@@ -1,0 +1,6 @@
+from gkernel.dtype.geometric.primitive import *
+
+
+
+x = Xax(Vec(0,0,1))
+print(x, type(x))

--- a/etc/201229 pln function addition.py
+++ b/etc/201229 pln function addition.py
@@ -1,0 +1,7 @@
+from gkernel.dtype.geometric.primitive import *
+from numpy import inf
+
+a = Vec(10, 10, 5)
+a = a*inf
+print(a)
+print(10*inf == 3*inf)

--- a/etc/bench/PRV vs consecutive index rendering.py
+++ b/etc/bench/PRV vs consecutive index rendering.py
@@ -1,0 +1,170 @@
+import glfw
+import OpenGL.GL as gl
+import random
+import numpy as np
+import ctypes
+import time
+
+"""
+benchmark if Primitive Reset Value is actually discarded in render pipeline thus saves time.
+
+PRV actually makes sense. Only time spent is itering all the indices. so 
+
+result: (elapse time in seconds)
+TEST render triangles PRV indexing RESULT: 0.0007646921600000001
+TEST render points PRV indexing RESULT: 0.0007367337600000002
+TEST render triangles consecutive indexing RESULT: 0.13444233311999998
+TEST render points no indexing RESULT: 8.275263999999999e-05
+"""
+
+glfw.init()
+window = glfw.create_window(1000, 1000, 'mywindow', None, None)
+glfw.make_context_current(window)
+
+# prepare array
+num_points = 1_000_000
+dtype = np.dtype([('vtx', 'f4', 4), ('clr', 'f4', 4)])
+points = np.ndarray(num_points, dtype)
+# create points
+for i in range(num_points):
+    point = [random.uniform(-1, 1), random.uniform(-1, 1), random.uniform(-1, 1), random.uniform(-1, 1)]
+    color = [random.random(), random.random(), random.random(), random.random()]
+    points[i] = point, color
+
+# create index
+consecutive_idx = np.array([i for i in range(num_points)], dtype='uint')
+prv_idx = np.array([0xff_ff_ff_ff for _ in range(num_points)], dtype='uint')
+
+# create program
+vrtx = """
+#version 450 core
+
+layout (location = 0) in vec4 vtx;
+layout (location = 1) in vec4 clr;
+
+out vec4 fclr;
+
+void main() {
+    gl_Position = vtx;
+    fclr = clr;
+}
+"""
+
+frgm = """
+#version 450 core
+
+in vec4 fclr;
+out vec4 FragColor;
+
+void main() {
+    FragColor = fclr;
+}
+"""
+vs = gl.glCreateShader(gl.GL_VERTEX_SHADER)
+gl.glShaderSource(vs, vrtx)
+gl.glCompileShader(vs)
+fs = gl.glCreateShader(gl.GL_FRAGMENT_SHADER)
+gl.glShaderSource(fs, frgm)
+gl.glCompileShader(vs)
+
+prgrm = gl.glCreateProgram()
+gl.glAttachShader(prgrm, vs)
+gl.glAttachShader(prgrm, fs)
+gl.glLinkProgram(prgrm)
+gl.glUseProgram(prgrm)
+# create buffers
+vbo = gl.glGenBuffers(1)
+consecutive_ibo = gl.glGenBuffers(1)
+prv_ibo = gl.glGenBuffers(1)
+
+# push consecutive data
+gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo)
+gl.glBufferData(gl.GL_ARRAY_BUFFER,
+                points.itemsize * points.size,
+                points,
+                gl.GL_DYNAMIC_DRAW)
+# set attribute pointer
+gl.glEnableVertexAttribArray(0)
+gl.glVertexAttribPointer(index=0,
+                         size=4,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=32,
+                         pointer=ctypes.c_void_p(0))
+gl.glEnableVertexAttribArray(1)
+gl.glVertexAttribPointer(index=1,
+                         size=4,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=32,
+                         pointer=ctypes.c_void_p(16))
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, consecutive_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                consecutive_idx.itemsize * consecutive_idx.size,
+                consecutive_idx,
+                gl.GL_DYNAMIC_DRAW)
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, prv_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                prv_idx.itemsize * prv_idx.size,
+                prv_idx,
+                gl.GL_DYNAMIC_DRAW)
+# prepare query
+qid = gl.glGenQueries(1)[0]
+
+# prepare render
+gl.glEnable(gl.GL_PRIMITIVE_RESTART_FIXED_INDEX)
+gl.glEnable(gl.GL_PROGRAM_POINT_SIZE)
+gl.glPointSize(1)
+# clean background
+gl.glClearColor(0, 0, 0, 0)
+gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+
+# test
+def test(setting, query, num_test, test_name):
+    setting()
+    elapse_times = []
+    for i in range(num_test):
+        gl.glBeginQuery(gl.GL_TIME_ELAPSED, qid)
+        query()
+        gl.glEndQuery(gl.GL_TIME_ELAPSED)
+        elapse_times.append(gl.glGetQueryObjectiv(qid, gl.GL_QUERY_RESULT))
+    glfw.swap_buffers(window)
+    ave = sum(t / num_test for t in elapse_times) / 1_000_000_000
+    print(f"TEST {test_name} RESULT: {ave}")
+
+
+num_test = 100
+is_test = True
+while not glfw.window_should_close(window):
+    if is_test:
+        test(setting=lambda: gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, prv_ibo),
+             query=lambda: gl.glDrawElements(gl.GL_TRIANGLES,
+                                             num_points,
+                                             gl.GL_UNSIGNED_INT,
+                                             ctypes.c_void_p(0)),
+             num_test=num_test,
+             test_name='render triangles PRV indexing')
+        test(setting=lambda: gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, prv_ibo),
+             query=lambda: gl.glDrawElements(gl.GL_POINTS,
+                                             num_points,
+                                             gl.GL_UNSIGNED_INT,
+                                             ctypes.c_void_p(0)),
+             num_test=num_test,
+             test_name='render points PRV indexing')
+        test(setting=lambda: gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, consecutive_ibo),
+             query=lambda: gl.glDrawElements(gl.GL_TRIANGLES,
+                              num_points,
+                              gl.GL_UNSIGNED_INT,
+                              ctypes.c_void_p(0)),
+             num_test=num_test,
+             test_name='render triangles consecutive indexing')
+        test(setting=lambda: gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0),
+             query=lambda: gl.glDrawArrays(gl.GL_POINTS, 0, num_points),
+             num_test=num_test,
+             test_name='render points no indexing')
+        is_test = False
+        print('TEST DONE')
+    glfw.poll_events()
+    time.sleep(1/60)    # check result and wait for close

--- a/etc/bench/PRVed vs shortened.py
+++ b/etc/bench/PRVed vs shortened.py
@@ -1,0 +1,346 @@
+import glfw
+import OpenGL.GL as gl
+import random
+import numpy as np
+import ctypes
+import time
+from ckernel.render_context.opengl_context.bffr_cache import BffrCache
+
+"""
+benchmark:
+assigning PRV values out of A% indices -> 
+render with full length index buffer -> 
+reassigning indices and render again
+vs
+remove indices by A% and tightly pack -> 
+render with shortened index buffer -> 
+reassign indices and render again
+
+In other words, want to know whether time used to pack tightly is worthy
+
+
+result:
+! RENDERING ELAPSE TIME is not purely GPU rendering time. it includes overhead organizing cache, block objects
+
+release-refilling 50%:
+TEST set_PRV_render_full_length RENDERING ELAPSE TIME: 0.002141264
+TEST set_PRV_render_full_length FULL ELAPSE TIME: 0.4623196601867676
+
+TEST release_no_pack RENDERING ELAPSE TIME: 0.0025272032
+TEST release_no_pack FULL ELAPSE TIME: 7.461874794960022
+
+TEST remove_render_tightly_packed RENDERING ELAPSE TIME: 1.0737603419000001
+TEST remove_render_tightly_packed FULL ELAPSE TIME: 16.600671648979187
+
+
+conclusion:
+Index tight packing reduces number of indices to render but packing itself takes too much time.
+Therefore release_fill operation is not fast enough to be executed commonly in frame-time.
+"""
+
+glfw.init()
+window = glfw.create_window(1000, 1000, 'mywindow', None, None)
+glfw.make_context_current(window)
+
+# prepare data
+num_points = 100000
+dtype = np.dtype([('vtx', 'f4', 4), ('clr', 'f4', 4)])
+points = np.ndarray(num_points, dtype)
+
+# create index
+test1_idx = BffrCache(np.dtype([('idx', 'uint')]), (0,), size=num_points)
+test2_idx = BffrCache(np.dtype([('idx', 'uint')]), (0,), size=num_points)
+test3_idx = BffrCache(np.dtype([('idx', 'uint')]), (0,), size=num_points)
+test1_blocks = []
+test2_blocks = []
+test3_blocks = []
+
+# create points
+for i in range(num_points):
+    point = [random.uniform(-1, 1), random.uniform(-1, 1), random.uniform(-1, 1), random.uniform(-1, 1)]
+    color = [random.random(), random.random(), random.random(), random.random()]
+    points[i] = point, color
+
+    b1 = test1_idx.request_block(size=1)
+    b1['idx'] = i
+    test1_blocks.append(b1)
+
+    b2 = test2_idx.request_block(size=1)
+    b2['idx'] = i
+    test2_blocks.append(b2)
+
+    b3 = test3_idx.request_block(size=1)
+    b3['idx'] = i
+    test3_blocks.append(b3)
+
+# prepare indices to replace
+pick_rate = 0.9
+i = list(range(num_points))
+cherry_picked = []
+for i in range(int(num_points * pick_rate)):
+    cherry_picked.append(i)
+
+# create program
+vrtx = """
+#version 450 core
+
+layout (location = 0) in vec4 vtx;
+layout (location = 1) in vec4 clr;
+
+out vec4 fclr;
+
+void main() {
+    gl_Position = vtx;
+    fclr = clr;
+}
+"""
+
+frgm = """
+#version 450 core
+
+in vec4 fclr;
+out vec4 FragColor;
+
+void main() {
+    FragColor = fclr;
+}
+"""
+vs = gl.glCreateShader(gl.GL_VERTEX_SHADER)
+gl.glShaderSource(vs, vrtx)
+gl.glCompileShader(vs)
+fs = gl.glCreateShader(gl.GL_FRAGMENT_SHADER)
+gl.glShaderSource(fs, frgm)
+gl.glCompileShader(vs)
+
+prgrm = gl.glCreateProgram()
+gl.glAttachShader(prgrm, vs)
+gl.glAttachShader(prgrm, fs)
+gl.glLinkProgram(prgrm)
+gl.glUseProgram(prgrm)
+# create buffers
+vbo = gl.glGenBuffers(1)
+test1_ibo = gl.glGenBuffers(1)
+test2_ibo = gl.glGenBuffers(1)
+test3_ibo = gl.glGenBuffers(1)
+
+# push consecutive data
+gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo)
+gl.glBufferData(gl.GL_ARRAY_BUFFER,
+                points.itemsize * points.size,
+                points,
+                gl.GL_DYNAMIC_DRAW)
+# set attribute pointer
+gl.glEnableVertexAttribArray(0)
+gl.glVertexAttribPointer(index=0,
+                         size=4,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=32,
+                         pointer=ctypes.c_void_p(0))
+gl.glEnableVertexAttribArray(1)
+gl.glVertexAttribPointer(index=1,
+                         size=4,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=32,
+                         pointer=ctypes.c_void_p(16))
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test1_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                test1_idx.active_bytesize,
+                test1_idx.array,
+                gl.GL_DYNAMIC_DRAW)
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test2_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                test2_idx.active_bytesize,
+                test2_idx.array,
+                gl.GL_DYNAMIC_DRAW)
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test3_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                test3_idx.active_bytesize,
+                test3_idx.array,
+                gl.GL_DYNAMIC_DRAW)
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0)
+
+# prepare render
+gl.glEnable(gl.GL_PRIMITIVE_RESTART_FIXED_INDEX)
+gl.glEnable(gl.GL_PROGRAM_POINT_SIZE)
+gl.glPointSize(1)
+# clean background
+gl.glClearColor(0, 0, 0, 0)
+gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+
+# test
+def benchmark(num_test, query, preset=lambda: (), test_name=None):
+    qid = gl.glGenQueries(1)[0]
+
+    preset()
+    render_times = []
+    operation_times = []
+    for i in range(num_test):
+        s = time.time()
+        gl.glBeginQuery(gl.GL_TIME_ELAPSED, qid)
+        query()
+        gl.glEndQuery(gl.GL_TIME_ELAPSED)
+        e = time.time()
+        operation_times.append(e-s)
+        while not gl.glGetQueryObjectiv(qid, gl.GL_QUERY_RESULT_AVAILABLE):
+            pass
+        render_times.append(gl.glGetQueryObjectiv(qid, gl.GL_QUERY_RESULT))
+    glfw.swap_buffers(window)
+    gl.glDeleteQueries(1, [qid])
+
+    truncated_ratio = 0.95
+    render_times.sort()
+    render_times = render_times[int(len(render_times)*(1-truncated_ratio)):int(len(render_times)*truncated_ratio)]
+    render_ave = sum(t / num_test for t in render_times) / 1_000_000_000
+    operation_times.sort()
+    operation_times = operation_times[int(len(operation_times)*(1-truncated_ratio)):int(len(operation_times)*truncated_ratio)]
+    op_ave = sum(t / num_test for t in operation_times)
+    if test_name is None:
+        test_name = query.__name__
+    print(f"TEST {test_name} RENDERING ELAPSE TIME: {render_ave}")
+    print(f"TEST {test_name} FULL ELAPSE TIME: {op_ave}")
+    print()
+
+
+def set_PRV_render_full_length():
+    """
+    assign PRV and maintain all blocks
+    :return:
+    """
+    removed = []
+    # pick
+    for i in cherry_picked:
+        block = test1_blocks[i]
+        removed.append(block['idx'][:])
+        block['idx'] = 0xff_ff_ff_ff
+    # push data
+    gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test1_ibo)
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test1_idx.active_bytesize,
+                    test1_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    # print(test1_idx.highest_indx, test1_idx.active_bytesize)
+    # render
+    gl.glDrawElements(gl.GL_POINTS,
+                      test1_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    # reset
+    for i in cherry_picked:
+        test1_idx[i]['idx'] = removed[i]
+    # push data
+
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test1_idx.active_bytesize,
+                    test1_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    # re render
+    gl.glDrawElements(gl.GL_POINTS,
+                      test1_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+
+
+def remove_render_tightly_packed():
+    """
+    for every block released, pack tight
+    :return:
+    """
+    removed = []
+    # pick
+    for i in cherry_picked:
+        block = test3_blocks[i]
+        removed.append(block['idx'][:])
+        block.release_refill(0xff_ff_ff_ff)
+    # push data
+    gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test3_ibo)
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test3_idx.active_bytesize,
+                    test3_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    # print(test3_idx.highest_indx, test3_idx.active_bytesize)
+    # render
+    gl.glDrawElements(gl.GL_POINTS,
+                      test3_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+
+    # reset
+    for i in cherry_picked:
+        new_block = test3_idx.request_block(size=1)
+        new_block['idx'] = removed[i]
+        test3_blocks[i] = new_block
+
+    # repush data
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test3_idx.active_bytesize,
+                    test3_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    # re render
+    gl.glDrawElements(gl.GL_POINTS,
+                      test3_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+
+
+def release_no_pack():
+    """
+    this releases block but do not pack tight
+    :return:
+    """
+    removed = []
+    # pick
+    for i in cherry_picked:
+        block = test2_blocks[i]
+        removed.append(block['idx'][:])
+        block.release(0xff_ff_ff_ff)
+
+    # push data
+    gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test2_ibo)
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test2_idx.active_bytesize,
+                    test2_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    # print(test2_idx.highest_indx, test2_idx.active_bytesize)
+    # render
+    gl.glDrawElements(gl.GL_POINTS,
+                      test2_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    # reset
+    for i in cherry_picked:
+        new_block = test2_idx.request_block(size=1)
+        new_block['idx'] = removed[i]
+        test2_blocks[i] = new_block
+    # repush data
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test2_idx.active_bytesize,
+                    test2_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    # re render
+    gl.glDrawElements(gl.GL_POINTS,
+                      test2_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+
+
+num_test = 10
+is_test = True
+while not glfw.window_should_close(window):
+    if is_test:
+        benchmark(num_test=num_test,
+                  query=set_PRV_render_full_length,
+                  preset=lambda: gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0))
+        benchmark(num_test=num_test,
+                  query=remove_render_tightly_packed,
+                  preset=lambda: gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0))
+        benchmark(num_test=num_test,
+                  query=release_no_pack,
+                  preset=lambda: gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0))
+        is_test = False
+        print('TEST DONE')
+    glfw.poll_events()
+    time.sleep(1 / 60)  # check result and wait for close

--- a/etc/bench/benchmark point consecutive indexing.py
+++ b/etc/bench/benchmark point consecutive indexing.py
@@ -1,0 +1,149 @@
+import glfw
+import OpenGL.GL as gl
+import random
+import numpy as np
+import ctypes
+import time
+
+"""
+
+result: no indexing is faster
+But difference is not that big at all to even consider abandoning indexing.
+
+result: (in seconds)
+no indexing: 0.00062450304
+consecutive indexing: 0.0006256812800000001 + ~0.000001
+random indexing: 0.0006394431999999999      + ~0.000003
+"""
+
+glfw.init()
+window = glfw.create_window(1000, 1000, 'mywindow', None, None)
+glfw.make_context_current(window)
+
+# create points
+points = []
+num_points = 1_000_000
+for _ in range(num_points):
+    point = [random.uniform(-1, 1), random.uniform(-1, 1), 0]
+    points.append(point)
+points = np.array(points, dtype='f4')
+
+# create index
+consecutive_idx = np.array([i for i in range(num_points)], dtype='uint')
+random_idx = list(range(num_points))
+random.shuffle(random_idx)
+random_idx = np.array(random_idx, dtype='uint')
+
+# create program
+vrtx = """
+#version 450 core
+
+layout (location = 0) in vec4 vtx;
+
+void main() {
+    gl_Position = vtx;
+}
+"""
+
+frgm = """
+#version 450 core
+
+
+out vec4 FragColor;
+
+void main() {
+    FragColor = vec4(1, 1, 0, 1);
+}
+"""
+vs = gl.glCreateShader(gl.GL_VERTEX_SHADER)
+gl.glShaderSource(vs, vrtx)
+gl.glCompileShader(vs)
+fs = gl.glCreateShader(gl.GL_FRAGMENT_SHADER)
+gl.glShaderSource(fs, frgm)
+gl.glCompileShader(vs)
+
+prgrm = gl.glCreateProgram()
+gl.glAttachShader(prgrm, vs)
+gl.glAttachShader(prgrm, fs)
+gl.glLinkProgram(prgrm)
+gl.glUseProgram(prgrm)
+
+# create buffers
+vbo = gl.glGenBuffers(1)
+consecutive_ibo = gl.glGenBuffers(1)
+random_ibo = gl.glGenBuffers(1)
+
+# push consecutive data
+gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo)
+gl.glBufferData(gl.GL_ARRAY_BUFFER,
+                points.itemsize * points.size,
+                points,
+                gl.GL_DYNAMIC_DRAW)
+# vertex attribute
+gl.glEnableVertexAttribArray(0)
+gl.glVertexAttribPointer(index=0,
+                         size=3,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=12,
+                         pointer=ctypes.c_void_p(0))
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, consecutive_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                consecutive_idx.itemsize * consecutive_idx.size,
+                consecutive_idx,
+                gl.GL_DYNAMIC_DRAW)
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, random_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                random_idx.itemsize * random_idx.size,
+                random_idx,
+                gl.GL_DYNAMIC_DRAW)
+# set point size
+gl.glEnable(gl.GL_PROGRAM_POINT_SIZE)
+gl.glPointSize(1)
+# prepare query
+query = gl.glGenQueries(1)[0]
+
+# clean background
+gl.glClearColor(0, 0, 0, 0)
+gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+#test
+print('test begin')
+num_test = 100
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, random_ibo)
+elapse_times = []
+for _ in range(num_test):
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, query)
+    gl.glDrawElements(gl.GL_POINTS,
+                      num_points,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    elapse_times.append(gl.glGetQueryObjectiv(query, gl.GL_QUERY_RESULT))
+print('random indexing:', sum(t/num_test for t in elapse_times) / 1_000_000_000)
+
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, consecutive_ibo)
+elapse_times = []
+for i in range(num_test):
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, query)
+    gl.glDrawElements(gl.GL_POINTS,
+                      num_points,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    elapse_times.append(gl.glGetQueryObjectiv(query, gl.GL_QUERY_RESULT))
+print('consecutive indexing:', sum(t/num_test for t in elapse_times) / 1_000_000_000)
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0)
+elapse_times = []
+for i in range(num_test):
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, query)
+    gl.glDrawArrays(gl.GL_POINTS, 0, num_points)
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    elapse_times.append(gl.glGetQueryObjectiv(query, gl.GL_QUERY_RESULT))
+print('no indexing:', sum(t/num_test for t in elapse_times) / 1_000_000_000)
+
+
+print('test done')

--- a/etc/bench/benchmark triangle consecutive indexing.py
+++ b/etc/bench/benchmark triangle consecutive indexing.py
@@ -1,0 +1,136 @@
+import glfw
+import OpenGL.GL as gl
+import random
+import numpy as np
+import ctypes
+import time
+
+"""
+
+"""
+
+glfw.init()
+window = glfw.create_window(1000, 1000, 'mywindow', None, None)
+glfw.make_context_current(window)
+
+# create points
+points = []
+num_points = 1_000_000
+for _ in range(num_points):
+    point = [random.uniform(-1, 1), random.uniform(-1, 1), 0]
+    points.append(point)
+points = np.array(points, dtype='f4')
+
+# create index
+consecutive_idx = np.array([i for i in range(num_points)], dtype='uint')
+random_idx = list(range(num_points))
+random.shuffle(random_idx)
+random_idx = np.array(random_idx, dtype='uint')
+
+# create program
+vrtx = """
+#version 450 core
+
+layout (location = 0) in vec4 vtx;
+
+void main() {
+    gl_Position = vtx;
+}
+"""
+
+frgm = """
+#version 450 core
+
+
+out vec4 FragColor;
+
+void main() {
+    FragColor = vec4(1, 1, 0, 1);
+}
+"""
+vs = gl.glCreateShader(gl.GL_VERTEX_SHADER)
+gl.glShaderSource(vs, vrtx)
+gl.glCompileShader(vs)
+fs = gl.glCreateShader(gl.GL_FRAGMENT_SHADER)
+gl.glShaderSource(fs, frgm)
+gl.glCompileShader(vs)
+
+prgrm = gl.glCreateProgram()
+gl.glAttachShader(prgrm, vs)
+gl.glAttachShader(prgrm, fs)
+gl.glLinkProgram(prgrm)
+gl.glUseProgram(prgrm)
+# create buffers
+vbo = gl.glGenBuffers(1)
+consecutive_ibo = gl.glGenBuffers(1)
+random_ibo = gl.glGenBuffers(1)
+
+# push consecutive data
+gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo)
+gl.glBufferData(gl.GL_ARRAY_BUFFER,
+                points.itemsize * points.size,
+                points,
+                gl.GL_DYNAMIC_DRAW)
+# set attribute pointer
+gl.glEnableVertexAttribArray(0)
+gl.glVertexAttribPointer(index=0,
+                         size=3,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=12,
+                         pointer=ctypes.c_void_p(0))
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, consecutive_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                consecutive_idx.itemsize * consecutive_idx.size,
+                consecutive_idx,
+                gl.GL_DYNAMIC_DRAW)
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, random_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                random_idx.itemsize * random_idx.size,
+                random_idx,
+                gl.GL_DYNAMIC_DRAW)
+# prepare query
+query = gl.glGenQueries(1)[0]
+
+# prepare render
+gl.glEnable(gl.GL_PROGRAM_POINT_SIZE)
+gl.glPointSize(1)
+# clean background
+gl.glClearColor(0, 0, 0, 0)
+gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+# test
+num_test = 100
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, random_ibo)
+elapse_times = []
+for _ in range(num_test):
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, query)
+    gl.glDrawElements(gl.GL_TRIANGLES,
+                      num_points,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    elapse_times.append(gl.glGetQueryObjectiv(query, gl.GL_QUERY_RESULT))
+print('random indexing:', sum(t/num_test for t in elapse_times) / 1_000_000_000)
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, consecutive_ibo)
+elapse_times = []
+for _ in range(num_test):
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, query)
+    gl.glDrawElements(gl.GL_TRIANGLES,
+                      num_points,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    elapse_times.append(gl.glGetQueryObjectiv(query, gl.GL_QUERY_RESULT))
+print('consecutive indexing:', sum(t/num_test for t in elapse_times) / 1_000_000_000)
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0)
+elapse_times = []
+for _ in range(num_test):
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, query)
+    gl.glDrawArrays(gl.GL_TRIANGLES, 0, num_points)
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    elapse_times.append(gl.glGetQueryObjectiv(query, gl.GL_QUERY_RESULT))
+print('no indexing:', sum(t/num_test for t in elapse_times) / 1_000_000_000)

--- a/etc/bench/refilling analysis.py
+++ b/etc/bench/refilling analysis.py
@@ -1,0 +1,206 @@
+import glfw
+import OpenGL.GL as gl
+import random
+import numpy as np
+import ctypes
+import time
+from ckernel.render_context.opengl_context.bffr_cache import BffrCache
+
+"""
+benchmark:
+elapse time profile for rendering with tight packing
+
+result: (job, time in second, share in elapse time)
+refill 10.757270574569702 77.6881393283%
+push_packed 3.25824e-05 0.0002353075%
+render_packed 9.12e-06 6.58639e-05%
+restore 3.0894084692001345 22.3114584628%
+repush 2.144e-06 1.54838e-05%
+rerender 1.18464e-05 8.55537e-05%
+
+conclusion:
+Packing is good when done behind, silently, but unusable if done vertex by vertex in frame render time.
+Case it could be compatible in frame render time is when a (really)big block is released. But even then
+simply rendering all will be faster. But packing is still a method of reducing render time if it could be
+done asynchronously.
+"""
+
+glfw.init()
+window = glfw.create_window(1000, 1000, 'mywindow', None, None)
+glfw.make_context_current(window)
+
+# prepare data
+num_points = 100000
+dtype = np.dtype([('vtx', 'f4', 4), ('clr', 'f4', 4)])
+points = np.ndarray(num_points, dtype)
+
+# create index
+test1_idx = BffrCache(np.dtype([('idx', 'uint')]), (0,), size=num_points)
+test1_blocks = []
+
+# create points
+for i in range(num_points):
+    point = [random.uniform(-1, 1), random.uniform(-1, 1), random.uniform(-1, 1), random.uniform(-1, 1)]
+    color = [random.random(), random.random(), random.random(), random.random()]
+    points[i] = point, color
+
+    b1 = test1_idx.request_block(size=1)
+    b1['idx'] = i
+    test1_blocks.append(b1)
+
+
+# prepare indices to replace
+pick_rate = 0.5
+i = list(range(num_points))
+cherry_picked = []
+for i in range(int(num_points * pick_rate)):
+    cherry_picked.append(i)
+
+# create program
+vrtx = """
+#version 450 core
+
+layout (location = 0) in vec4 vtx;
+layout (location = 1) in vec4 clr;
+
+out vec4 fclr;
+
+void main() {
+    gl_Position = vtx;
+    fclr = clr;
+}
+"""
+
+frgm = """
+#version 450 core
+
+in vec4 fclr;
+out vec4 FragColor;
+
+void main() {
+    FragColor = fclr;
+}
+"""
+vs = gl.glCreateShader(gl.GL_VERTEX_SHADER)
+gl.glShaderSource(vs, vrtx)
+gl.glCompileShader(vs)
+fs = gl.glCreateShader(gl.GL_FRAGMENT_SHADER)
+gl.glShaderSource(fs, frgm)
+gl.glCompileShader(vs)
+
+prgrm = gl.glCreateProgram()
+gl.glAttachShader(prgrm, vs)
+gl.glAttachShader(prgrm, fs)
+gl.glLinkProgram(prgrm)
+gl.glUseProgram(prgrm)
+# create buffers
+vbo = gl.glGenBuffers(1)
+test1_ibo = gl.glGenBuffers(1)
+test2_ibo = gl.glGenBuffers(1)
+test3_ibo = gl.glGenBuffers(1)
+
+# push consecutive data
+gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo)
+gl.glBufferData(gl.GL_ARRAY_BUFFER,
+                points.itemsize * points.size,
+                points,
+                gl.GL_DYNAMIC_DRAW)
+# set attribute pointer
+gl.glEnableVertexAttribArray(0)
+gl.glVertexAttribPointer(index=0,
+                         size=4,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=32,
+                         pointer=ctypes.c_void_p(0))
+gl.glEnableVertexAttribArray(1)
+gl.glVertexAttribPointer(index=1,
+                         size=4,
+                         type=gl.GL_FLOAT,
+                         normalized=gl.GL_FALSE,
+                         stride=32,
+                         pointer=ctypes.c_void_p(16))
+
+gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test1_ibo)
+gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                test1_idx.active_bytesize,
+                test1_idx.array,
+                gl.GL_DYNAMIC_DRAW)
+
+# prepare render
+gl.glEnable(gl.GL_PRIMITIVE_RESTART_FIXED_INDEX)
+gl.glEnable(gl.GL_PROGRAM_POINT_SIZE)
+gl.glPointSize(1)
+# clean background
+gl.glClearColor(0, 0, 0, 0)
+gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+qid = gl.glGenQueries(1)[0]
+
+# test
+num_test = 10
+is_test = True
+times = {}
+for _ in range(num_test):
+    removed = []
+    # pick
+    s = time.time()
+    for i in cherry_picked:
+        block = test1_blocks[i]
+        removed.append(block['idx'][:])
+        block.release_refill(0xff_ff_ff_ff)
+    e = time.time()
+    times.setdefault('refill', []).append(e-s)
+
+    # push data
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, qid)
+    gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, test3_ibo)
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test1_idx.active_bytesize,
+                    test1_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    times.setdefault('push_packed', []).append(gl.glGetQueryObjectiv(qid, gl.GL_QUERY_RESULT)/1_000_000_000)
+
+    # render
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, qid)
+    gl.glDrawElements(gl.GL_POINTS,
+                      test1_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    times.setdefault('render_packed', []).append(gl.glGetQueryObjectiv(qid, gl.GL_QUERY_RESULT)/1_000_000_000)
+
+    # reset
+    s = time.time()
+    for i in cherry_picked:
+        new_block = test1_idx.request_block(size=1)
+        new_block['idx'] = removed[i]
+        test1_blocks[i] = new_block
+    e = time.time()
+    times.setdefault('restore', []).append(e-s)
+
+    # repush data
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, qid)
+    gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER,
+                    test1_idx.active_bytesize,
+                    test1_idx.array,
+                    gl.GL_DYNAMIC_DRAW)
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    times.setdefault('repush', []).append(gl.glGetQueryObjectiv(qid, gl.GL_QUERY_RESULT)/1_000_000_000)
+
+    # re render
+    gl.glBeginQuery(gl.GL_TIME_ELAPSED, qid)
+    gl.glDrawElements(gl.GL_POINTS,
+                      test1_idx.highest_indx + 1,
+                      gl.GL_UNSIGNED_INT,
+                      ctypes.c_void_p(0))
+    gl.glEndQuery(gl.GL_TIME_ELAPSED)
+    times.setdefault('rerender', []).append(gl.glGetQueryObjectiv(qid, gl.GL_QUERY_RESULT)/1_000_000_000)
+
+for k, v in times.items():
+    v.sort()
+    times[k] = sum(v[int(num_test*0.05):int(num_test*0.95)])/num_test
+summed_t = sum(times.values())
+for k, v in times.items():
+    print(k, v, f"{round((v/summed_t)*100, 10)}%")

--- a/etc/casting dict to dict.py
+++ b/etc/casting dict to dict.py
@@ -1,0 +1,12 @@
+
+
+a = {'a': 'a'}
+print(dict(a))
+a = [1,2,3]
+print(list(a))
+a = (1,2,3)
+print(tuple(a))
+b = {1,2,3}
+print(set(b))
+a = 3.2
+print(float(a))

--- a/etc/default message decorator.py
+++ b/etc/default message decorator.py
@@ -1,0 +1,23 @@
+
+
+
+class A:
+    log = ''
+    def operation(func):
+        def wrapper(self, *args, **kwargs):
+            try:
+                func(self, *args, **kwargs)
+                self.log = 'operation success'
+            except Exception as e:
+                self.log = e
+        return wrapper
+
+
+    @operation
+    def operate(self, a):
+        if a == 1:
+            raise
+
+a = A()
+a.operate(0)
+print(a.log)

--- a/etc/descriptor.py
+++ b/etc/descriptor.py
@@ -1,0 +1,25 @@
+
+
+class D:
+    def __init__(self, name):
+        self._name = '_'+name
+
+    def __set__(self, instance, value):
+        print('setting')
+        setattr(instance, self._name, value)
+
+    def __get__(self, instance, owner):
+        print('getting')
+        return getattr(instance, self._name)
+
+class C:
+    a = D('a')
+    def __init__(self):
+        self.a = 10
+
+c = C()
+print(c.a)
+print(c._a)
+c._a = 20
+print(c.a, c._a)
+c.a = 30

--- a/etc/gkernel/201230 line intersection test.py
+++ b/etc/gkernel/201230 line intersection test.py
@@ -1,0 +1,66 @@
+from gkernel.dtype.geometric.primitive import *
+
+
+def test_intx(pnt_s, pnt_e, ray_o, ray_n):
+    line = Lin.from_pnts(pnt_s, pnt_e)
+    ray = Ray.from_pnt_vec(ray_o, ray_n)
+
+    intx = line.intx_ray(ray)
+    if intx is None:
+        print('intersection yield no result')
+    elif isinstance(intx, Lin):
+        print(f"intersection yield a line {intx} and is the line {intx == line}")
+    else:
+        # compare vectors to check result
+        vec_to_p = Vec.from_pnts(ray_o, intx).normalize()
+        ray_norm = ray_n.normalize()
+        print(f"intersecting at {intx}")
+        print(f"vector correct? {vec_to_p == ray_norm}")
+    print()
+
+
+print('TESTS ON XY(2D) PLANE:')
+ps, pe, ro = Pnt(0, 0, 0), Pnt(12, 0, 0), Pnt(0, 6, 0)
+print('test: ray crossing middle of axis line')
+test_intx(ps, pe, ro, Vec(1, -1, 0))
+print('test: ray crossing start of line')
+test_intx(ps, pe, ro, Vec(0, -1, 0))
+print('test: ray crossing end of line')
+test_intx(ps, pe, ro, Vec(2, -1, 0))
+print('test: ray directing to the line but over parameter')
+test_intx(ps, pe, ro, Vec(10, -1, 0))
+print('test: ray directing to the line but under parameter')
+test_intx(ps, pe, ro, Vec(-1, -1, 0))
+print('test: ray not directing to the line')
+test_intx(ps, pe, ro, Vec(1, 1, 0))
+print('test: ray parallel to the line and not crossing')
+test_intx(ps, pe, ro, Vec(1, 0, 0))
+print('test: ray parallel opposite to the line and not crossing')
+test_intx(ps, pe, ro, Vec(-1, 0, 0))
+
+print()
+print('TEST ON 1D(LINE ON RAY):')
+ps, pe, rn = Pnt(0, 0, 0), Pnt(20, 10, 0), Vec(2, 1, 0)
+print('test: ray collinear with line and directions equal')
+test_intx(ps, pe, ps, rn)
+test_intx(ps, pe, pe, -rn)
+print('test: ray starts on the line but directions do not follow line')
+test_intx(ps, pe, ps, Vec(0, 1, 0))
+test_intx(ps, pe, pe, Vec(0, 1, 0))
+print('test: ray collinear with line and ray starts outside')
+test_intx(ps, pe, ps + rn*-100, rn)
+test_intx(ps, pe, ps + rn*100, -rn)
+print('test: ray starts at third of line')
+test_intx(ps, pe, ps + Vec.from_pnts(ps, pe) / 3, rn)
+test_intx(ps, pe, ps + Vec.from_pnts(ps, pe) / 3, -rn)
+
+print()
+print('TEST ON 3D USING SIMPLE CUBE:')
+ps, pe, ro = Pnt(0, 0, 0), Pnt(0, 10, 10), Pnt(10, 0, 0)
+print('test: ray intersecting middle of the line on yz plane')
+test_intx(ps, pe, ro, Vec.from_pnts(ro, Lin.from_pnts(ps, pe).pnt_at(0.5)))
+print('test: ray missing middle of the line')
+test_intx(ps, pe, ro, Vec.from_pnts(ro, Lin.from_pnts(ps, pe).pnt_at(0.5)) + Vec(z=1))
+print('test: ray missing middle of the line but pointing at the line')
+test_intx(ps, pe, ro, Vec.from_pnts(ro, Lin.from_pnts(ps, pe).pnt_at(4))/5)
+

--- a/etc/gkernel/201231 triangle intersection test.py
+++ b/etc/gkernel/201231 triangle intersection test.py
@@ -1,0 +1,35 @@
+from gkernel.dtype.geometric.primitive import *
+from gkernel.tools import Intersector as intx
+
+
+def no_culling_tester(tgl, ray):
+    result = intx.intx(tgl, ray)
+    print('result', result)
+    print('culling disabling works', result == intx.intx(tgl.copy().reverse(), ray))
+    print()
+
+
+print('SIMPLE 2D TEST:')
+
+tgl = Tgl([0, 0, 0], [10, 0, 0], [0, 10, 0])
+print("test : from above")
+no_culling_tester(tgl, Ray(o=[5, 5, 5], v=[0, -0.5, -1]))
+print("test : from below")
+no_culling_tester(tgl, Ray(o=[5, 5, -5], v=[0, -0.5, 1]))
+print("test : not intersecting")
+no_culling_tester(tgl, Ray(o=[5, 5, -5], v=[0, 0.5, 1]))
+no_culling_tester(tgl, Ray(o=[5, 5, 5], v=[0, 0.5, 1]))
+print()
+
+print('TEST IN CUBE')
+d = 10
+tgl = Tgl([d, 0, 0], [0, d, 0], [0, 0, d])
+no_culling_tester(tgl, Ray(o=[d, d, d], v=[-d, -d, -d]))
+no_culling_tester(tgl, Ray(o=[d, d, d], v=[-1, 0, 0]))
+no_culling_tester(tgl, Ray(o=[d, d, d], v=[-1, 0, -1]))
+print()
+
+print('TEST RAY STARTING FROM ON THE TRIANGLE')
+no_culling_tester(tgl, Ray(o=[d/2, d/2, 0], v=[0, 0, 1]))
+no_culling_tester(tgl, Ray(o=(Pnt(d/2, d/2, 0) + Vec.from_pnts(Pnt(0,0,d), Pnt(d/2,d/2, 0)).amplify(10)).xyz, v=[0, 0, 1]))
+

--- a/etc/gkernel/flat to vertical view.py
+++ b/etc/gkernel/flat to vertical view.py
@@ -1,0 +1,6 @@
+from gkernel.dtype.geometric.primitive import Pnt
+import numpy as np
+
+
+p = np.array([0, 1, 2, 3]).view(Pnt)
+print(p.arr)

--- a/etc/gkernel/multiply transformation matrix to plane.py
+++ b/etc/gkernel/multiply transformation matrix to plane.py
@@ -1,0 +1,7 @@
+from gkernel.dtype.geometric.primitive import Pln
+
+a = 1
+p = Pln([100, 100, 100], [-a, a, 0], [-a, -a, a], [a, a, a])
+p[:] = 10
+print(p)
+print(p.arr)

--- a/etc/gkernel/test named vectors.py
+++ b/etc/gkernel/test named vectors.py
@@ -1,0 +1,40 @@
+from gkernel.dtype.geometric.primitive import *
+#
+# v = Vec(10, 10, 10)
+#
+# p0 = Pnt(10, 10, 10)
+# p1 = Pnt(5, 5, 5)
+#
+# zv = ZeroVec()
+#
+# print('point to vector')
+# print(p0 - p1)
+#
+# print('move point')
+# print(p0 + v)
+# print(p0 - v)
+#
+# print('named to common Vec')
+# print(zv + v)
+# print(v + zv)
+# print(zv + p0)
+# print(p0 + zv)
+#
+# print('scalar math')
+# print(zv * 3)
+# print(zv - v / 3)
+# print((zv + v) / 3)
+#
+# print()
+# print('named vs named test')
+# xvec = XVec()
+# t = zv
+# zv += v
+# print(zv, t, t == zv)
+# print(t + xvec)
+# print(-xvec)
+a = ZeroVec()
+a[:] = a * 10
+# print(a * 10)
+print(a.normalize())
+print(a.as_vec())

--- a/etc/gkernel/test plane standarization.py
+++ b/etc/gkernel/test plane standarization.py
@@ -1,0 +1,16 @@
+from gkernel.dtype.geometric.primitive import Pln
+from gkernel.dtype.nongeometric.matrix import MoveMat
+
+# print('test 0: correct standardization')
+a = Pln([100, 50, 30], x=(5, 5, 3))
+# print(a.arr)
+# print(a.trnsf_mat.arr)
+# print('test 1: copy')
+# print(a.copy().arr)
+print('test 2: check TM after calculation')
+m = MoveMat(10, 10, 5)
+b = m * a
+print(b.interleaved, type(b))
+print(b.trnsf_mat.interleaved)
+
+# print(np.array([[1,2,3,4], [5,6,7,8], [10,11,12,13], [14,15,16,17]]).view(Pln))

--- a/etc/gkernel/testing vector amplify.py
+++ b/etc/gkernel/testing vector amplify.py
@@ -1,0 +1,9 @@
+from gkernel.dtype.geometric.primitive import Vec
+
+a = Vec(10, 20, 3)
+print(a.normalize())
+print(a.amplify(10))
+# import numpy as np
+# a = np.array([0, 1, 2])
+a[:] = 10
+print(a)

--- a/etc/gkernel/timing problem inbetween glfw callbak and draw thread.py
+++ b/etc/gkernel/timing problem inbetween glfw callbak and draw thread.py
@@ -1,0 +1,48 @@
+import glfw
+
+from doodler import *
+from mkernel import Model, Tgl, Vec, Pnt
+from wkernel import Window
+
+
+class MyWindow(Window):
+    def __init__(self):
+        super().__init__(500, 500, 'my window 1', monitor=None, shared=None)
+        self.framerate = 60
+        # enable camera move
+        self.cameras[0].tripod.lookat((100, 100, 100), (0, 0, 0), (0, 0, 1))
+        self.cameras.attach_fps_dolly(0)
+
+        # create model
+        self.model = Model()
+        e = 100
+        self.model.append_shape(Tgl([0, 0, 0], [e, 0, 0], [0, e, 0]))
+        self.model.append_shape(Tgl([0, 0, 0], [0, e, 0], [0, 0, e]))
+        self.model.append_shape(Tgl([0, 0, 0], [e, 0, 0], [0, 0, e]))
+        glfw.set_cursor(self.glfw_window, glfw.create_standard_cursor(glfw.CROSSHAIR_CURSOR))
+
+    def draw(self, frame_count=None):
+        with self.panes[0] as v:
+            with self.cameras[0] as c:
+                v.clear(.5, .5, .5, 1)
+                self.model.render()
+
+                e = 100
+                triangle([0, 0, 0], [e, 0, 0], [0, e, 0])
+                triangle([0, 0, 0], [0, e, 0], [0, 0, e])
+                triangle([0, 0, 0], [e, 0, 0], [0, 0, e])
+                self.devices.mouse.cursor_goto_center()
+                self.model.intersect(c.frusrum_ray(*v.local_cursor()))
+
+                # glitch
+                zoff = -50
+                e = 10
+                tm = c.tripod.in_plane.r.trnsf_mat
+                p0 = tm * Pnt(e, 0, zoff)
+                p1 = tm * Pnt(0, e, zoff)
+                p2 = tm * Pnt(0, 0, zoff)
+                triangle(p0.xyz, p1.xyz, p2.xyz)
+                print(Vec() == 0)
+
+
+MyWindow().run_all(1)

--- a/etc/gl/array nested array byte stream test.py
+++ b/etc/gl/array nested array byte stream test.py
@@ -1,0 +1,57 @@
+import glfw
+import OpenGL.GL as gl
+import numpy as np
+from gkernel.dtype.geometric.primitive import Pnt, Tgl
+from gkernel.dtype.nongeometric.matrix.primitive import MoveMat
+
+# test for single vertex, color interleaved
+# prepare context
+glfw.init()
+w = glfw.create_window(100, 100, '4', None, None)
+glfw.make_context_current(w)
+a = gl.glGenBuffers(1)
+gl.glBindBuffer(gl.GL_ARRAY_BUFFER, a)
+
+# build array
+dtype = np.dtype([('pnt', 'f4', 4), ('clr', 'f4', 3)])
+raw_arr = [((0, 0, 0, 0), (1, 1, 1)), ((0, 0, 0, 0), (1, 1, 1))]
+arr = np.array(raw_arr, dtype=dtype)
+
+# modify viewed
+p0 = arr['pnt'][0].reshape(4, 1).view(Pnt)
+p0[0] = 1
+
+# push data
+gl.glBufferData(target=gl.GL_ARRAY_BUFFER, size=32, data=arr, usage=gl.GL_STATIC_DRAW)
+# check buffer
+k = gl.glGetBufferSubData(gl.GL_ARRAY_BUFFER, 0, 32)
+print(k, len(k))
+
+glfw.terminate()
+print()
+
+# test for m
+# prepare context
+glfw.init()
+w = glfw.create_window(100, 100, '4', None, None)
+glfw.make_context_current(w)
+a = gl.glGenBuffers(1)
+gl.glBindBuffer(gl.GL_ARRAY_BUFFER, a)
+
+# build array
+dtype = np.dtype([('pnt', 'f4', 4), ('clr', 'f4', 3)])
+raw_arr = [((0, 0, 0, 1), (1, 1, 1)), ((0, 0, 0, 1), (1, 1, 1)), ((0, 0, 0, 1), (1, 1, 1))]
+arr = np.array(raw_arr, dtype=dtype)
+print(arr)
+# modify viewed
+tgl = arr['pnt'][0:3].T.view(Tgl)
+tgl[:] = MoveMat(10, 10, 10) * tgl
+print(arr)
+
+# push data
+gl.glBufferData(target=gl.GL_ARRAY_BUFFER, size=84, data=arr, usage=gl.GL_STATIC_DRAW)
+# check buffer
+k = gl.glGetBufferSubData(gl.GL_ARRAY_BUFFER, 0, 84)
+print(k, len(k))
+
+glfw.terminate()

--- a/etc/gl/chained view.py
+++ b/etc/gl/chained view.py
@@ -1,0 +1,8 @@
+from UVT.env.MVC.view import View
+
+a = View(0, 10, 100, 100, None)
+b = View(0, 0.5, lambda x: x-20, 0.5, a)
+
+print(b.x, b.y, b.w, b.h)
+a.y = 20
+print(b.x, b.y, b.w, b.h)

--- a/etc/gl/draw bonding.py
+++ b/etc/gl/draw bonding.py
@@ -1,0 +1,22 @@
+from UVT import Window, DrawBit
+
+
+class C(DrawBit):
+    def draw(self):
+        print('i am a child')
+        super().draw()
+
+
+class CC(DrawBit):
+    def draw(self):
+        print('i am a child of child')
+
+
+w = Window(200, 200, 'window1', None, None)
+
+c = C()
+w.ftree_append_children(c)
+cc = CC()
+cc.ftree_set_parent(c)
+
+w.run_all()

--- a/etc/gl/duplicate buffer push test.py
+++ b/etc/gl/duplicate buffer push test.py
@@ -1,0 +1,39 @@
+import glfw
+import OpenGL.GL as gl
+import time
+
+"""
+conclusion:
+    redundant binding seems to be not ignored by OpenGL context,
+    but is it hardware wise is not tested.
+"""
+# prepare context
+glfw.init()
+w = glfw.create_window(100, 100, '4', None, None)
+glfw.make_context_current(w)
+# create buffers
+n = 10000
+buffer = gl.glGenBuffers(1)
+buffers = [gl.glGenBuffers(1) for _ in range(n)]
+# iteration time
+iter_time = None
+s = time.time()
+for i in range(n):
+    pass
+e = time.time()
+iter_time = e - s
+print(iter_time)
+# redundant binding lead time
+s = time.time()
+for i in range(n):
+    gl.glBindBuffer(gl.GL_ARRAY_BUFFER, buffer)
+e = time.time()
+print(e-s-iter_time)
+# meaningful binding lead time
+s = time.time()
+for b in buffers:
+    gl.glBindBuffer(gl.GL_ARRAY_BUFFER, b)
+e = time.time()
+print(e-s-iter_time)
+
+glfw.terminate()

--- a/etc/gl/single buffer draw triangle.py
+++ b/etc/gl/single buffer draw triangle.py
@@ -1,0 +1,29 @@
+from UVT import Window, gl
+from UVT.doodle import *
+
+
+class W(Window):
+    def __init__(self):
+        super().__init__(200, 200, 'window1')
+
+    def setup(self):
+        self._inited = False
+        self.framerate = 4
+        self.count = 0
+
+    def draw(self):
+        super().draw()
+        if self.count%4 == 2:
+            print('a')
+            background(0,0,0,0)
+            triangle((0, 0, 0), (1, 0, 0), (0, -1, 0))
+            triangle((0, 0, 0), (0, 1, 0), (-1, 0, 0))
+        elif self.count%4 == 0:
+            print('b')
+            background(0,0,0,0)
+            triangle((0, 0, 0), (1, 0, 0), (0, 1, 0))
+            triangle((0, 0, 0), (-1, 0, 0), (0, -1, 0))
+        self.count += 1
+
+w = W()
+w.run()

--- a/etc/gl/single frame triangle drawing with element array.py
+++ b/etc/gl/single frame triangle drawing with element array.py
@@ -1,0 +1,40 @@
+from UVT import Window
+import UVT.pipeline as comp
+import glfw
+import numpy as np
+
+window1 = Window.new_window(200, 200, 'f', monitor=None, shared=None)
+
+window1.viws.register(0.25, 0.25, 0.5, 0.5)
+
+@window1.run_all(lyr = window1.lyrs[0], viw=window1.viws[1], cam=window1.cams[0])
+def a():
+    w = window1
+    # raw data
+    vertex = [[-0.8, -0.8, 0], [0.8, -0.8, 0], [-0.8, 0.8, 0], [0.8, 0.8, 0]]
+    vertex = comp.ConSingleNamedData('coord', vertex, 'f')
+    index = comp.ConSingleNamedData('indx', (0, 1, 2, 3), 'uint')
+
+    # opengl objects
+    vao = comp.ConVertexArray(w)
+    vbo = comp.ConVertexBuffer(w)
+    ibo = comp.ConIndexBuffer(w)
+
+    # push raw data into buffers
+    vertex_pusher = comp.PushBufferData(w, vbo.out0_vrtx_bffr, vertex.out0_ndata)
+    data_vbo = vertex_pusher.out0_data_bffr
+    data_ibo = comp.PushBufferData(w, ibo.out0_indx_bffr, index.out0_ndata).out0_data_bffr
+
+    # make vertex attribut buffers(VABO?) and index buffer(IBO) known to VAO
+    enhancer = comp.EnhanceVertexArray(w)
+    enhancer.set_inputs(vao.vrtx_arry, data_vbo, data_ibo)
+
+    # check component graph refreshing
+    new_vertex = [[-0.8, -0.8, 0], [0.8, -0.8, 0], [-0.8, 0.8, 0], [0.5, 0.5, 0]]
+    vertex_pusher.in1_data = comp.ConSingleNamedData('coord', new_vertex, 'f').out0_ndata
+
+    # draw
+    de = comp.RenderElement(w, enhancer.out0_vrtx_arry, data_ibo, w.gl.GL_TRIANGLE_STRIP)
+    de.out0_render_result
+
+Window.run_all()

--- a/etc/gl/single frame triangle drawing.py
+++ b/etc/gl/single frame triangle drawing.py
@@ -1,0 +1,32 @@
+from UVT import Window
+import UVT.pipeline as comp
+import glfw
+import numpy as np
+
+window1 = Window.new_window(200,200, 'f', monitor=None, shared=None)
+
+with window1 as w:
+    vertex = [[-1, -1, 0], [1, -1, 0], [0, 1, 0], [1,1,0]]
+    va = comp.ConSingleNamedData('coord', vertex, 'f')
+    vbo = comp.ConVertexBuffer(w)
+    vao = comp.ConVertexArray(w)
+    #
+    buffer_pusher = comp.PushBufferData(w)
+    enabler = comp.EnableVertexAttribute(w)
+
+    buffer_pusher.in1_data = va.out0_ndata
+    buffer_pusher.in0_bffr = vbo.out0_vrtx_bffr
+    enabler.in0_vrtx_arry = vao.vrtx_arry
+    enabler.vrtx_attr = va.out0_ndata
+    #
+    joiner = comp.JoinVrtxArryVrtxBffr(w)
+    joiner.in0_vrtx_arry = vao.vrtx_arry
+    joiner.out0_vrtx_bffr = vbo.out0_vrtx_bffr
+
+    tri_drawer = comp.RenderArray(w, joiner.vrtx_arry_out, comp.Bound(1, 4))
+
+    # tri_drawer.vrtx_arry = joiner.vrtx_arry_out
+
+    print(tri_drawer.render_attempt)
+
+Window.run_all(1)

--- a/etc/heap generator.py
+++ b/etc/heap generator.py
@@ -1,0 +1,23 @@
+import heapq
+
+def gen():
+    h = [123, 2,3,3,4,5,12,3,5,1,12,2,3,2]
+    # for i in h:
+    #     yield i
+
+# g = gen()
+# for i in g:
+#     print(i)
+a = {1,2,3}
+b = [4,2,1]
+a.update(b)
+print(a)
+# try:
+#     while True:
+#         if next(g) == 12:
+#             print('twelve')
+#             break
+# except StopIteration as e:
+#     print('end iter')
+# else:
+#     print('else')

--- a/etc/inherit instance.py
+++ b/etc/inherit instance.py
@@ -1,0 +1,9 @@
+class A:
+    pass
+
+a = A()
+
+class B(a):
+    def __new__(cls, *args, **kwargs):
+        print(args, kwargs)
+    pass

--- a/etc/init inherit.py
+++ b/etc/init inherit.py
@@ -1,0 +1,37 @@
+class K:
+    def __init__(self,a,b):
+        print('init K')
+        self.a = a
+
+class A:
+    def __init__(self, a, b):
+        print('init A')
+
+class B:
+    def __new__(cls, *args, **kwargs):
+        print('new of B', cls, args, kwargs)
+        return super().__new__(cls)
+
+    def __init__(self, a, b):
+        print('init B')
+
+class C(type):
+    def __new__(cls, name, bases, dct):
+        bases = (B, *bases)
+        return super().__new__(cls, name, bases, dct)
+    # def __init__(self):
+    #     print('init C')
+    pass
+
+class D(K, dict):
+    pass
+    # def __init__(self, a, b):
+    #     pass
+
+k = C('k', (str,), {})(10, 20)
+
+b = type('b', (A, str), {})
+print(b.__new__(b))
+d = D(10, 20)
+print(type(d), isinstance(d, K), isinstance(d, dict))
+print(d)

--- a/etc/init none-ing.py
+++ b/etc/init none-ing.py
@@ -1,0 +1,15 @@
+class M(type):
+    def __new__(cls, clsname, bases, dct):
+        typ = super().__new__(cls, clsname, bases, dct)
+        print(typ)
+        return typ(10, 20)
+
+class A(metaclass=M):
+
+
+    def __init__(self, a, b):
+
+        print('initing')
+        self.a = a
+        self.b = b
+a = A()

--- a/etc/interface mechanism.py
+++ b/etc/interface mechanism.py
@@ -1,0 +1,581 @@
+import weakref as wr
+from collections import namedtuple, deque
+from collections.abc import Iterable
+import inspect
+import warnings
+import heapq
+
+class NodeSpvr:
+    """
+    Supervisor of nodes
+
+    Stores relationship and hierarchy between nodes
+    Only cares relationship between
+    """
+
+    def __init__(self, inst):
+        self._graph = {}
+        self._needto_update = wr.WeakSet()
+
+        self._graph[inst] = {'dist':0, 'rels':{}}
+        self._needto_update.add(inst)
+
+    def _relate(self, this_node, out, inp, right_node):
+        """
+        Write down relationship
+
+        Literally imagine two nodes connected by a line,
+        of which two ends from left to right are the output and the input of two nodes.
+        :param this_node:
+        :param out:
+        :param inp:
+        :param right_node:
+        :return:
+        """
+        self.rels(this_node).setdefault(out, {}).setdefault(right_node, set()).add(inp)
+
+    def build_rel(self, out, inp):
+        """
+        Build relationship between two nods via interfaces
+
+        :param out:
+        :param inp:
+        :return:
+        """
+
+        l_supv, r_supv = out.intf_holder._comp_spvr, inp.intf_holder._comp_spvr
+        # two graphs are islands so need to be merged beforehand
+        is_merged = False
+        if l_supv != r_supv:
+            # simply update dict and assign new supervisor to instances(nodes)
+            l_supv._graph.update(r_supv._graph)
+            for node in r_supv._graph:
+                node._comp_spvr = l_supv
+            is_merged = True
+
+        # check distance and update if needed
+        supv = l_supv
+        l_node, r_node = out.intf_holder, inp.intf_holder
+
+        # loop check ?
+        # check only relationships is being built within an island
+        # and right is before left
+        if not is_merged:
+            for nxt_node in supv._node_rightward(r_node):
+                if nxt_node == l_node:
+                    warnings.warn("Trying to make a look. Connection not accepted")
+                    return
+                if supv.dist(nxt_node) > supv.dist(l_node):
+                    break
+
+        # write relationship and calculate distance,
+        # push value, push r_node to update que as new value has been just pushed
+        supv._relate(l_node, out, inp, r_node)
+        supv._graph[r_node]['dist'] = supv.dist(l_node) + 1
+        inp._intf_obj = out._intf_obj
+        supv.push_needto_update(r_node)
+
+        # update distance of all r_node's rightward
+        # no need to align nodes. just que
+        que = deque([r_node])
+
+        while que:
+            node = que.popleft()
+            this_dist = supv.dist(node)
+            for o, i, r_node in supv._node_full_rels(node):
+                if this_dist >= supv.dist(r_node):
+                    supv._graph[r_node]['dist'] = this_dist + 1
+                    que.append(r_node)
+
+    def disconnect(self, instance, intf):
+        """
+        Remove all connections of which one end is given interface
+        :param instance:
+        :param intf:
+        :return:
+        """
+        # !Q does disconnection affect dist of nodes?
+        # it doesn't violate hierarchy but could be cleaned to maintain dist understandable?
+        # TODO: algorithm for maintaining nodes' (attr) dist relatively close
+        if intf.intf_sign == Input:
+            print('disconnection', instance, intf)
+            for node, dist_rels in self._graph.items():
+                for out, rights in dist_rels['rels'].items():
+                    for right, inps in rights.items():
+                        if intf in inps:
+                            inps.deregister(intf)
+                            if not inps:
+                                del rights[right]
+                            break
+
+        elif intf.intf_sign == Output:
+            d = self.rels(instance)
+            if intf in d:
+                for inp, rights in d.items():
+                    for right, inps in rights.items():
+                        for inp in inps:
+                            # reset r_node's input into default value
+                            delattr(right, inp.intf_name)
+                del d[intf]
+        else:
+            NotImplementedError
+        self.push_needto_update(instance)
+
+    def push_needto_update(self, instance):
+        """
+        Push into need to upadate que
+
+        Needing to update means node's (def) operate has to executed to update output value.
+        :param instance:
+        :return:
+        """
+        self._needto_update.add(instance)
+
+    def dist(self, node):
+        """
+        Hierarchial identifier
+
+        Closer to 0 means it has to be calculated beforehand.
+        Higher means it has to be calculated later.
+        :param node:
+        :return:
+        """
+        return self._graph[node]['dist']
+
+    def rels(self, node):
+        """
+        Return info dict describing rightward nodes of this node
+        :param node:
+        :return:
+        """
+        return self._graph[node]['rels']
+
+    def update_tomake_updated(self, target_node=None):
+        """
+        Build update graph then push values consequently
+
+        From update_que, find all nodes needing update in rightward order
+        then for each execute (def) operate and push outputs rightward
+        :return:
+        """
+        # adding i for dist(n) being the same
+        # !Q is _update_que node that has run (def) operate or that has to run operate?
+        for nxt_node in self._node_rightward(self._needto_update):
+            # all nodes before end_node can be calculated even if it doesn't affect end_node's value
+            if self.dist(nxt_node) > self.dist(target_node):
+                break
+            if nxt_node in self._needto_update: # reset que
+                self._needto_update.remove(nxt_node)
+            nxt_node.calculate()  # run to update outputs
+            # push outputs to next node
+            for out, inp, r_node in self._node_full_rels(nxt_node):
+                inp._intf_obj = out._intf_obj
+
+            if nxt_node == target_node:
+                # push next of nxt_node needto update and stop updating
+                for out, inp, r_node in self._node_full_rels(nxt_node):
+                    self._needto_update.add(r_node)
+                break
+
+    def _graph_full_rels(self):
+        """
+        Generator of all relationships
+
+        :param node: relationship of
+        :return: Generator('full_rel_info', ('output', 'input', 'right_node'))
+        """
+        np = namedtuple('graph_full_rels', ('dist', 'node', 'output', 'input', 'right_node'))
+        for node, dist_rels in self._graph.items():
+            for dist, rels in dist_rels.items():
+                for out, rights in rels.items():
+                    for right, inps in rights.items():
+                        for inp in inps:
+                            yield np(dist, node, out, inp, right)
+
+    def _node_full_rels(self, node):
+        """
+        Generator of relationships of given node
+
+        :param node: relationship of
+        :return: Generator('node_full_rels', ('output', 'input', 'right_node'))
+        """
+        np = namedtuple('node_full_rels', ('output', 'input', 'right_node'))
+        for out, rights in self._graph[node]['rels'].items():
+            for right, inps in rights.items():
+                for inp in inps:
+                    yield np(out, inp, right)
+
+    def _node_rightward(self, roots):
+        """
+        Generator of rightward nodes
+
+        Returns rightwards nodes of given roots in hierarchical order
+        :param roots: Nodes tracking from. Multiple nodes can be given.
+        :return: Generator
+        """
+
+        if isinstance(roots, Iterable):
+            heap = list([(self.dist(n), i, n) for i, n in enumerate(roots)])
+            entry = len(roots)
+            visited = set(roots)
+        else:
+            heap = [(self.dist(roots), 0, roots)]
+            entry = 1
+            visited = {roots}
+
+        heapq.heapify(heap)
+        while heap:
+            dist, _, node = heapq.heappop(heap)
+            yield node
+            for out, rights in self.rels(node).items():
+                for right, ins in rights.items():
+                    if right not in visited:
+                        heapq.heappush(heap, (self.dist(right), entry, right))
+                        visited.add(right)
+                        entry += 1
+
+    def __len__(self):
+        return len(self._graph)
+
+
+class IntfObj:
+    """
+    Wrapper storing additional properties to wrapped type
+
+    From interface's view, instance of this is not assigned to another or removed until
+    the intf is __delete__ -> meaning resetting to default value.
+    """
+
+    def __init__(self, instance, name, sign, value):
+        """
+        Store interface properties
+        :param instance:
+        :param name:
+        :param sign:
+        :param value:
+        :return:
+        """
+        self._intf_holder = wr.ref(instance)
+        self._intf_is_deleted = False
+        self._intf_name = name
+        self._intf_sign = sign
+        self._intf_obj = value  # real value wrapped
+
+    def __str__(self):
+        return f"< {self._intf_sign.__name__} : {type(self._intf_obj).__name__} : {self._intf_obj} >"
+
+    @property
+    def intf_name(self):
+        return self._intf_name
+
+    @property
+    def intf_holder(self):
+        ins = self._intf_holder()
+        if ins is None:
+            raise NotImplementedError
+        return ins
+
+    @property
+    def intf_sign(self):
+        return self._intf_sign
+
+    @property
+    def intf_is_deleted(self):
+        return self._intf_is_deleted
+
+    @property
+    def real_value(self):
+        return self._intf_obj
+
+    def __add__(self, other):
+        if isinstance(other, IntfObj):
+            return self._intf_obj.__add__(other._intf_obj)
+        return self.real_value.__add__(other)
+
+    def __sub__(self, other):
+        if isinstance(other, IntfObj):
+            return self._intf_obj.__sub__(other._intf_obj)
+        return self._intf_obj.__sub__(other)
+
+    def __truediv__(self, other):
+        if isinstance(other, IntfObj):
+            return self._intf_obj.__truediv__(other._intf_obj)
+        return self._intf_obj.__truediv__(other)
+
+    def __floordiv__(self, other):
+        if isinstance(other, IntfObj):
+            return self._intf_obj.__floordiv__(other._intf_obj)
+        return self._intf_obj.__floordiv__(other)
+
+    def __mul__(self, other):
+        if isinstance(other, IntfObj):
+            return self._intf_obj.__mul__(other._intf_obj)
+        return self._intf_obj.__mul__(other)
+
+    def __getitem__(self, item):
+        return self._intf_obj.__getitem__(item)
+
+    def __getattr__(self, item):
+        return getattr(self._intf_obj, item)
+
+
+class IntfDescriptor:
+    """
+    Interface node for input and output
+
+    To control setting value
+    """
+
+    def __init__(self, def_val):
+        # parse initing code line identify name
+        c = inspect.getframeinfo(inspect.currentframe().f_back).code_context[0]
+        self._name = c.split(self.__class__.__name__)[0].strip().split('=')[0].strip()
+        self._record_name = f'_{self.__class__.__name__}_{self._name}'
+        self._def_val = def_val
+
+    def __set__(self, instance, value):
+        """
+        !!! only input triggers (def) push to update que
+
+        :param instance:
+        :param value:
+        :return:
+        """
+
+
+    def __get__(self, instance, owner) -> IntfObj:
+        """
+        Getting input value
+
+        !!! Getting input and output triggers (def) update
+        1. make value up-to-date by telling node supervisor to update
+        2. return intf value
+
+        :param instance:
+        :param owner:
+        :return:
+        """
+        self._check_init(instance)
+        instance._comp_spvr.update_tomake_updated(type(self), instance)
+        return getattr(instance, self._record_name)
+
+    def __delete__(self, instance):
+        """
+        Disconnection from output
+
+        1. Remove connection in node graph
+        2. Reset with default value
+
+        :param instance:
+        :return:
+        """
+        self._check_init(instance)
+        instance._comp_spvr.disconnect(instance, getattr(instance, self._record_name))
+        intf_obj = IntfObj(instance, self._name, type(self), self._def_val)
+        setattr(instance, self._record_name, intf_obj)
+
+    def _check_init(self, instance):
+        """
+        Initiate interface
+
+        1. add attribute into the instance
+        2. add signature's attribute set, e.g. _inputs, into the instance
+        3. add node grapher to the instance
+        :param instance:
+        :return:
+        """
+        # add attriute
+        if not hasattr(instance, self._record_name):
+            # 1 use default value if there isn't one
+            intf_obj = IntfObj(instance, self._name, type(self), self._def_val)
+            setattr(instance, self._record_name, intf_obj)
+            # 2 collect instance attr_name, then set with sign
+            inst_dict = instance.__dict__.setdefault('_intfs', {})
+            inst_dict.setdefault(self, set()).add(self._record_name)
+        # 3 add node grapher if there isn't
+        if not hasattr(instance, '_comp_spvr'):
+            setattr(instance, '_comp_spvr', NodeSpvr(instance))
+
+
+class Input(IntfDescriptor):
+    """
+    Designate input value
+    """
+
+    def __set__(self, instance, value):
+        """
+        Handles assigning python dd to InterfaceValueContainer
+
+        :param instance:
+        :param value:
+        :return:
+        """
+        self._check_init(instance)
+
+        if isinstance(value, IntfObj):  # if connecting node to node
+            if value.intf_sign == Input: # if connecting input -> input interfaces
+                raise AttributeError("direction should be (output) -> (input)")
+
+            instance._comp_spvr.disconnect(instance, getattr(instance, self._record_name))
+            instance._comp_spvr.build_rel(value, getattr(instance, self._record_name))
+
+        else:  # if putting raw value
+            self.__delete__(instance)   # existing connection has to be removed as this is explicit __set__
+            getattr(instance, self._record_name)._intf_obj = value
+
+
+class Output(IntfDescriptor):
+    """
+    Output Interface
+
+    Manages setting getting deleting output value
+    """
+
+    def __set__(self, instance, value):
+        """
+        Sets output value
+
+        Only one case is accepted :
+        Instance's internal operation trying to set value to the output
+        else, output value of node is not allowed to be set as it's always the result of the node's (def) operate.
+        And as (def) operate will only be run by (obj) _comp_spvr, there is no need to set rightward to be updated.
+
+        :param instance: Node
+        :param value:
+        :return:
+        """
+        self._check_init(instance)
+        # guess if assigning value is called inside the node
+        calling_frame = inspect.currentframe().f_back
+        frameinfo = inspect.getframeinfo(calling_frame)
+        local_attr = inspect.getargvalues(calling_frame).locals
+        # 3 guesses:
+        # guess if the node has attribute named of function setting value in
+        # guess if that attribute is a method
+        # guess if 'self' is in local arg and is the node
+        if hasattr(instance, frameinfo.function):
+            if inspect.ismethod(getattr(instance, frameinfo.function)):
+                if 'self' in local_attr and local_attr['self'] == instance:
+                    value = value.real_value if isinstance(value, IntfObj) else value
+                    getattr(instance, self._record_name)._intf_obj = value
+                    # if node's output is updated, right of it has to have values in and set to update
+                    # pushing is needed for the case (def) operate is executed explicitly?
+                    # or can't it be executed that way? -> it can't i suppose
+                    # instance._comp_spvr.push_rightward_update_que(instance, getattr(instance, self._record_name))
+                    return
+        raise AttributeError("Output can't be set explicitly")
+
+
+
+if __name__ == '__main__':
+
+    class K:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+
+    class A:
+        i = Input(None)
+        o = Output(None)
+
+        def operate(self):
+            self.o = self.i
+            print('operation A')
+
+
+    class B:
+        first_in = Input('')
+        second_in = Input('')
+        o = Output(0)
+
+        def operate(self):
+            print('operation B')
+            self.o = self.first_in + self.second_in
+
+    class Upper:
+        i = Input(None)
+        o = Output(None)
+
+        def operate(self):
+            print('operate Upper')
+            self.o = self.i.upper()
+
+    class FirstLast:
+        i = Input(None)
+        o1 = Output(None)
+        o2 = Output(None)
+
+        def operate(self):
+            print('operate FirstLast')
+            self.o1 = self.i[0]
+            self.o2 = self.i[-1]
+
+    class Join:
+        i1 = Input(None)
+        i2 = Input(None)
+        o = Output(None)
+
+        def operate(self):
+            print('operate Join')
+            self.o = self.i1 + self.i2
+
+
+    def text_two_nodes():
+
+        node1, node2 = A(), B()
+        print(node1.i, node1.o)
+        node1.i = 'first in_'
+        print(node1.o)
+        print()
+        node2.first_in = node1.o
+        print(node2._comp_spvr._needto_update)
+        node2.second_in = node1.o
+        print('inputing two values done')
+        print()
+        node1.i = 'other in'
+        print(node2.o)
+        node2.second_in = 'this is second in'
+        print(node2.o)
+        node1.i = node2.o
+        print()
+        print()
+        del node1.o
+        print(node2.first_in)
+        print(node1.o)
+
+    def test_three_nodes():
+        u, fl, j = Upper(), FirstLast(), Join()
+        u.i = 'abc'
+        fl.i = u.o
+        j.i1 = fl.o1
+        j.i2 = fl.o2
+        print(j.o)
+        j.i2 = u.o
+        print(j.i1, j.i2, j.o)
+        del j.i1
+        j.i1 = 'new'
+        print(j.o)
+        fl.i = 'fff'
+        print('ddd')
+        j.i2 = fl.o1
+        print(j.i1, j.i2)
+        print(u.o)
+        print(j.o)
+        print(j._comp_spvr._needto_update)
+        print(j.o)
+        u.i = 'ddddd'
+        for i in j._comp_spvr._node_full_rels(u):
+            print(i)
+        print(u.o)
+        j.i1 = j.i2 = u.o
+        print(j.o)
+        u.i = '233'
+        j.i2 = fl.o1
+        u.i = fl.i = 'kk'
+        print(j.o)
+        print()
+        del u.i
+        del j.i1, j.i2
+        print(j.o)
+    test_three_nodes()

--- a/etc/isinstance check.py
+++ b/etc/isinstance check.py
@@ -1,0 +1,30 @@
+class M:
+    _wrapper_classes= {}
+    def __new__(cls, a,b,c,d):
+        typ = type('A', (A, type(d)), {})
+        print('ddd')
+        inst = typ(a,b,c,d)
+        print('kkk')
+        return inst
+
+class A:
+    def __init__(self, *args, **kwargs):
+        instance, name, sign, value = args
+        super.__init__(self, value)
+        self._intf_holder = instance
+        self._intf_is_deleted = False
+        self._intf_name = name
+        self._intf_sign = sign
+        self._intf_obj = value  # real value wrapped
+
+    def __str__(self):
+        return 'ddd'
+
+
+a = M(10,20,30,40)
+b = M('s')
+print(a)
+print(id(type(a)), id(type(b)))
+print(isinstance(a, int))
+print(isinstance(a, A))
+print(isinstance(a, type(20)))

--- a/etc/memory firstfit alocating test.py
+++ b/etc/memory firstfit alocating test.py
@@ -1,0 +1,24 @@
+
+
+
+arr = list(range(10))
+block_pool = [(0, 10)]
+
+def aloc_firstfit(arr, size):
+    if size == 0:
+        raise
+    for i, (sidx, block_size) in enumerate(block_pool):
+        leftover = block_size - size
+        if 0 <= leftover:
+            if leftover == 0:
+                block_pool.pop(i)
+            else:
+                block_pool[i] = (sidx + size, leftover)  # append new free space
+            return arr[sidx:sidx+size]
+    raise Exception('overflow')
+
+print(aloc_firstfit(arr, 1))
+print(aloc_firstfit(arr, 3))
+print(aloc_firstfit(arr, 6))
+
+print(block_pool)

--- a/etc/meta redirecting.py
+++ b/etc/meta redirecting.py
@@ -1,0 +1,19 @@
+class Meta(type):
+    def __new__(cls, clsname, bases, dct):
+        print('calling meta new')
+        return super().__new__(cls, clsname, bases, dct)
+
+    def __init__(self, *args, **kwargs):
+        print(self, *args, **kwargs)
+        # self.value = value
+
+    def __instancecheck__(self, instance):
+        print(instance)
+
+class A(metaclass=Meta):
+    def __init__(self, v):
+        self.value = v
+
+a = A(10)
+print(a.value)
+print(isinstance(A, int))

--- a/etc/noding/example.py
+++ b/etc/noding/example.py
@@ -1,0 +1,61 @@
+from JINTFP import NodeBody, Input, Output
+
+
+class MyNode(NodeBody):
+    # input descr. will only accept instance of `typs`
+    in0 = Input(def_val='', typs=str)
+    in1 = Input(def_val='', typs=str)
+
+    out = Output()
+
+    def __init__(self, id):
+        # NodeBody's `__init__` has to be called
+        # to initiate instance as a Node
+        super().__init__()
+        self._do_upper = False
+        self._id = id
+
+    def calculate(self, in0, in1):
+        # user should provide matching number of
+        # attribute to use them in calculation
+        print(f'RUNNING Node : {self._id}')
+        if self._do_upper:
+            return (in0 + in1).upper()
+        return in0 + in1
+
+    def set_upper(self):
+        # except inheriting and initiating,
+        # concrete Node acts the same as any other class
+        # user can extend its functionality as they wish to
+        self._do_upper = True
+        # reset to be recalculated with cached value
+        self.reset_downstream()
+
+node0 = MyNode(0)
+node1 = MyNode(1)
+node2 = MyNode(2)
+print('>>> building graph')
+node2.in0 = node0.out
+node2.in1 = node1.out
+
+print('>>> building graph more')
+node3, node4 = MyNode(3), MyNode(4)
+node3.in0, node3.in1 = node2.out, node1.out
+node0.in0 = node4.out
+# feeding inputs
+node4.in0, node4.in1 = 'x', 'y'
+node0.in1 = 'a'
+node1.in0, node1.in1 = 'm', 'n'
+print('\n>>> getting outputs')
+print(node3.out, node4.out)
+
+...
+print('>>> tweaking calculation')
+node0.set_upper()
+print('>>> getting unaffected')
+print(node1.out)
+print('>>> getting affected')
+print(node3.out)
+...
+print('>>> getting real value')
+print(node3.out.r, type(node3.out.r))

--- a/etc/noding/getting explained.py
+++ b/etc/noding/getting explained.py
@@ -1,0 +1,98 @@
+class _IntfDescriptor:
+    ...
+    def __get__(self, instance: NodeBody, owner):
+        intf = instance.get_intf(self._name)
+        intf._recalculate_upstream()
+        return intf
+    ...
+
+
+class _NodeMember(FamilyMember):
+    ...
+    def _recalculate_upstream(self, _visited=None, debug=''):
+        """
+        recalculated upstream to get up to date result
+
+        :return:
+        """
+        if _visited is None: # initiate recursion
+            _visited = set()
+        if self._is_calculated(): # base condition
+            return True
+        is_parent_recalculated = True # flag for checking permanent recalculation
+        # recursivly calculate upstream before calculating current
+        for member in self.fm_all_parents():
+            if not isinstance(member, _NodeMember):
+                continue
+            if member not in _visited:
+                _visited.add(member)
+                is_parent_recalculated &= member._recalculate_upstream(_visited, debug+' '*4)
+        self._set_calculated()
+        self._run_calculation()
+
+        # if this node is set to permanently recalculate
+        # or one of parent is set so, pass this signal downstream
+        if self._calculate_permanent or not is_parent_recalculated:
+            self._reset_calculated()
+        return self._is_calculated()
+    ...
+
+
+class NodeBody(_NodeMember):
+    ...
+    def _run_calculation(self):
+        """
+        Execute concrete function and push value downstream
+        :return:
+        """
+        # collect input
+        input_vs = OrderedDict()
+        for intf in self.input_intfs:
+            if intf.sibling_intf_allowed:
+                input_vs.setdefault(intf.family_name, []).register(intf.get_calculated_value())
+            else:
+                input_vs[intf] = intf.get_calculated_value()
+
+        # run actual function defined by user
+        try:
+            results = self.calculate(*input_vs.values())
+        except Exception as e:
+            # set all outputs NULL
+            results = [NullValue(f"calculation fail of {self}")] * len(self.output_intfs)
+            # record and print error status
+            self._calculation_status = e
+            self.print_status()
+        else:
+            # wrap singular result and match length
+            results = [results] if not isinstance(results, (list, tuple)) else list(results)
+            results += [NullValue("calculation didn't return enough values")] * (len(self.output_intfs) - len(results))
+            self._calculation_status = ''
+        finally:
+            # push calculation result down to outputs
+            for result, intf in zip(results, self.output_intfs):
+                intf.set_provoke_value(result)
+    ...
+
+
+class _InputBffr(_IntfBffr):
+    ...
+    def _run_calculation(self):
+        """
+        Nothing to do
+        :return:
+        """
+        pass
+    ...
+
+
+class _OutputBffr(_IntfBffr):
+    ...
+    def _run_calculation(self):
+        """
+        Just push value downstream
+        :return:
+        """
+        for child in self.fm_all_children():
+            if isinstance(child, _IntfBffr):
+                child._value = self._value
+    ...

--- a/etc/noding/refreshing.py
+++ b/etc/noding/refreshing.py
@@ -1,0 +1,27 @@
+from UVT.pipeline.nodes._node import *
+
+
+class A(NodeBody):
+    i = Input()
+    o = Output()
+    def calculate(self):
+        print('calculated')
+        self.o = self.i.r*10
+
+class B(NodeBody):
+    i = Input()
+    o = Output()
+    def calculate(self):
+        print('calculate B')
+        self.o = self.i.r*1.1
+
+
+a = A()
+b = B()
+a.i = 20
+b.i = a.o
+print(b.o)
+a.i = 30
+print(b.o)
+b.refresh()
+print(b.o)

--- a/etc/noding/setting explained.py
+++ b/etc/noding/setting explained.py
@@ -1,0 +1,49 @@
+# assignment will call descriprot's `__set__`
+# then Interface buffer's `set_provoke_value`
+# then `_signal_downstream`
+some_node.some_input = another_node.some_output
+
+class _IntfDescriptor:
+    ...
+    def __set__(self, instance: NodeBody, value):
+        # retrive stored interface buffer
+        intf = instance.get_intf(self._name)
+        intf.set_provoke_value(value)
+    ...
+
+
+class _InputBffr(_IntfBffr):
+    ...
+    def set_provoke_value(self, value):
+        """
+        Set interface value
+
+        whilst building relationship and resetting calculated flag
+        :param value:
+        :return:
+        """
+        super().set_provoke_value(value)
+        # by default relationship is monopoly so clear
+        self.fm_clear_parent()
+        # make relationship
+        if isinstance(value, _IntfBffr):
+            # set relationship between interface
+            self.fm_append_member(parent=value, child=self)
+            value = value._value
+        self._value = value
+        self._signal_downstream()
+
+    def _signal_downstream(self, visited=None, debug=''):
+        """
+        Reset children's calculated sign
+        :return:
+        """
+    if visited == None:
+        visited = set()
+    if self._is_calculated():
+        self._reset_calculated()
+        for child in self.fm_all_children():
+            if child not in visited:
+                visited.add(child)
+                child.reset_downstream(visited, debug + ' ' * 4)
+    ...

--- a/etc/numpy/is column vector good.py
+++ b/etc/numpy/is column vector good.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+
+a = np.eye(4)
+a[0][3] = 10
+b = np.array([1,0,10, 1])
+# b = b.reshape((4,1))
+print(a.dot(b))
+# print(a*b)
+a = np.array([1,2,3,4])
+b = np.array([4,5,6,7])
+print(a.dot(b))
+
+a = [[1,0,0,10],
+     [0,1,0,0],
+     [0,0,1,0],
+     [0,0,0,1]]
+b = [[0,0,0,1],
+     [1,0,0,0],
+     [0,1,0,0],
+     [0,0,1,0]]
+a = np.array(a)
+b = np.array(b)
+print(b.T)
+print(b.T.dot(a))

--- a/etc/numpy/looking for correct struct.py
+++ b/etc/numpy/looking for correct struct.py
@@ -1,0 +1,65 @@
+import random
+import time
+import numpy as np
+from gkernel.dtype.geometric.primitive import Pnt
+from gkernel.dtype.nongeometric.matrix.primitive import MoveMat
+"""
+what is the correct struct?
+
+1. applying transformation matrix
+2. weaving into struct
+3. manipulating single object
+
+"""
+
+# found! use this pattern
+mm = MoveMat(10, 10, 10)
+dtype = np.dtype([('pnt', 'f4', 4), ('clr', 'f4', (3,))])
+n = 6
+interleaved = []
+for _ in range(n):
+    interleaved.append(((1, 11, 111, 1), (0, 0, 0)))
+interleaved = np.array(interleaved, dtype)
+
+print('this is interleaved buffer:')
+print(interleaved)
+print()
+print('this is linear geometric data:')
+
+# pnts = interleaved['pnt'].T.view(np.ndarray)
+# print(interleaved['pnt'].shape)
+print(interleaved['pnt'].shape)
+pnts = interleaved[[1, 2, 3]]
+print(pnts)
+# pnts[:] = np.dot(pnts, mm.T)
+# pnts[:] = pnts.dot(mm.T)
+# print(pnts[0,0])
+print(pnts[0])
+pnts['pnt'] = 100
+print()
+print(pnts)
+print(pnts.base)
+k = interleaved['pnt'][..., (0, 3)]
+k[:] = 100
+print()
+print(interleaved)
+# print()
+# print(interleaved['pnt'].T)
+# print(interleaved['pnt'][:, :, (0, 1)])
+# print(interleaved['pnt'].T.shape)
+# print(pnts)
+# p = interleaved['pnt'][0].view(Pnt)
+# print(b)
+# p[0] = 10
+# print(b)
+#
+# print()
+# b[:] = mm * b
+# print(interleaved)
+# p[0] = 50
+# print(interleaved)
+# print(b)
+# # print()
+# # c = np.apply_along_axis(lambda x: mm * x, axis=1, arr=b)
+# # print(c)
+# # print(p)

--- a/etc/numpy/pointer slice.py
+++ b/etc/numpy/pointer slice.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+
+
+a = np.array([[1,2],[3,4]])
+print(a)
+b = a[:,0]
+print(b)
+b[0] = 10
+print(a)

--- a/etc/numpy/single structured array.py
+++ b/etc/numpy/single structured array.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+
+dtype = np.dtype([('a', 'uint', 3), ('b', 'f', 2)])
+print(dtype)
+data = [ ((0,1,2), (0,2)), ((0,1,2), (2,2)) ]
+arr = np.array(data, dtype=dtype)
+print(arr)
+print(arr['a'])
+
+
+dtype = np.dtype([('a', 'uint', 3)])
+print(dtype)
+data = ((1,2,3),)
+arr = np.array(data, dtype=dtype)
+print(arr)
+print(arr['a'], data, dtype)

--- a/etc/numpy/store array into structured array.py
+++ b/etc/numpy/store array into structured array.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+mat = np.eye(4)
+mat2 = np.eye(3)
+
+dtype = np.dtype([('a', np.ndarray)])
+print(dtype)
+arr = np.zeros(1, dtype)
+arr[0] = (mat,)
+# print(arr)
+# print('ddddddddd')
+# print(arr[0])
+# arr2 = np.array((mat2,), dtype)
+# print(arr, type(arr))
+# print(type(arr['a']))
+# print(arr['a'],)
+# print(np.array(2))
+# print(arr[0])
+# k = np.vstack((arr, arr2))
+# print(k.shape, arr.shape)
+# print(k['a'][0])

--- a/etc/numpy/struct array apply tm bench.py
+++ b/etc/numpy/struct array apply tm bench.py
@@ -1,0 +1,57 @@
+import random
+import time
+import numpy as np
+from gkernel.dtype.geometric.primitive import Pnt
+
+"""
+compare transformation matrix application
+
+test 0, struct stores other array as an object
+test 1, struct stores point in ndarray with vertical vector shape
+
+
+is this true?
+"""
+
+# power self test
+n = 10000
+test_n = 10
+
+ave = 0
+dtype = np.dtype([('pnt', Pnt), ('color', 'f4', 3)])
+# test 0
+for _ in range(test_n):
+    arr = []
+    for _ in range(n):
+        p = Pnt(*[random.random() for _ in range(3)])
+        c = [random.random() for _ in range(3)]
+        arr.append((p, c))
+
+    a = np.array(arr, dtype=dtype)
+
+    s = time.time()
+    for i in range(n):
+        a[i]['pnt'] = np.dot(np.ndarray((4, 4)), a[i]['pnt'])
+    e = time.time()
+    ave += e - s
+print(ave/test_n)
+
+# test 1
+ave = 0
+dtype = np.dtype([('pnt', 'f8', (4, 1)), ('color', 'f4', 3)])
+for _ in range(test_n):
+    arr = []
+    for _ in range(n):
+        p = [[i] for i in range(4)]
+        p[3] = [1]
+        c = [random.random() for _ in range(3)]
+        arr.append((p, c))
+    a = np.array(arr, dtype=dtype)
+
+    s = time.time()
+    s = time.time()
+    for i in range(n):
+        a[i]['pnt'] = np.dot(np.ndarray((4, 4)), a[i]['pnt'])
+    e = time.time()
+    ave += e - s
+print(ave / test_n)

--- a/etc/numpy/struct array self power bench.py
+++ b/etc/numpy/struct array self power bench.py
@@ -1,0 +1,77 @@
+import random
+import time
+import numpy as np
+from gkernel.dtype.geometric.primitive import Pnt
+
+"""
+compare power calculation time with different array struct
+
+test 0, struct stores other array as an object
+test 1, struct stores point in ndarray with vertical vector shape
+test 2, struct stores point in ndarray with flat vector shape
+
+there is linear improvement going 0 -> 1 -> 2 but 
+temporal conclusion is that convenience being able to store array obj(0) in struct can overcomes time loss ?
+
+is this true?
+"""
+
+# power self test
+n = 10000
+test_n = 10
+
+ave = 0
+dtype = np.dtype([('pnt', Pnt), ('color', 'f4', 3)])
+# test 0
+for _ in range(test_n):
+    arr = []
+    for _ in range(n):
+        p = Pnt(*[random.random() for _ in range(3)])
+        c = [random.random() for _ in range(3)]
+        arr.append((p, c))
+
+    a = np.array(arr, dtype=dtype)
+
+    s = time.time()
+    for i in range(n):
+        a[i] = a[i][0]**2, a[i][1]**2
+    e = time.time()
+    ave += e - s
+print(ave/test_n)
+
+# test 1
+ave = 0
+dtype = np.dtype([('pnt', 'f8', (4, 1)), ('color', 'f4', 3)])
+for _ in range(test_n):
+    arr = []
+    for _ in range(n):
+        p = [[random.random()] for _ in range(4)]
+        c = [random.random() for _ in range(3)]
+        arr.append((p, c))
+    a = np.array(arr, dtype=dtype)
+
+    np.dot(np.ndarray((4, 4)), a['pnt'])
+    s = time.time()
+    for i in range(n):
+        a[i] = a[i][0] ** 2, a[i][1] ** 2
+    e = time.time()
+    ave += e - s
+print(ave / test_n)
+
+# test 2
+ave = 0
+dtype = np.dtype([('pnt', 'f8', 4), ('color', 'f4', 3)])
+for _ in range(test_n):
+    arr = []
+    for _ in range(n):
+        p = [random.random() for _ in range(4)]
+        c = [random.random() for _ in range(3)]
+        arr.append((p, c))
+    a = np.array(arr, dtype=dtype)
+
+    s = time.time()
+    for i in range(n):
+        a[i] = a[i][0] ** 2, a[i][1] ** 2
+    e = time.time()
+    ave += e - s
+print(ave / test_n)

--- a/etc/pipeline example.py
+++ b/etc/pipeline example.py
@@ -1,0 +1,11 @@
+from pipeline import Pipeline, comp
+
+pipeline = Pipeline()
+a = comp.Integer(10)
+b = comp.Integer(5)
+addition = comp.Add()
+pipeline.relate(a, a.value_out, addition.f, addition)
+pipeline.relate(b, b.value_out, addition.b, addition)
+
+pipeline.calculate()
+print(addition.vlaue_out)

--- a/etc/python/chained.py
+++ b/etc/python/chained.py
@@ -1,0 +1,106 @@
+# class MemberIterator:
+#     def __init__(self):
+#         raise NotImplementedError
+#     # def __next__(self):
+#     #     raise NotImplementedError
+#     def __iter__(self):
+#         raise NotImplementedError
+#     def __len__(self):
+#         raise NotImplementedError
+#
+# class I(MemberIterator):
+#
+#     def __init__(self, iterator, next):
+#         self._iterator = iterator
+#         self._next = next
+#
+#     def __iter__(self):
+#         for i in self._iterator:
+#             yield i
+#         for i in self._iterator(self._next):
+#             yield i
+#
+#
+# class TypeIterator(MemberIterator):
+#
+#     def __init__(self, iterator, typ):
+#         self._iterator = iterator
+#         self._typ = typ
+#
+#     def __iter__(self):
+#         for i in self._iterator:
+#             if isinstance(i, self._typ):
+#                 yield i
+#
+#     def __call__(self, member):
+#         self._iterator = self._iterator(member)
+#         return self
+#         # return self.__class__(self._iterator.__call__(member), self._typ)
+#
+# class ParentIterator(MemberIterator):
+#
+#     def __init__(self, start_at):
+#         self._start_at = start_at
+#
+#     def __iter__(self):
+#         for parent in self._start_at._l:
+#             yield parent
+#
+#     def __call__(self, start_at):
+#         return self.__class__(start_at)
+#
+# class ChildrenIterator(MemberIterator):
+#
+#     def __init__(self, start_at):
+#         self._start_at = start_at
+#
+#     def __iter__(self):
+#         for child in self._start_at._l:
+#             yield child
+#
+#     def __call__(self, start_at):
+#         self._start_at = start_at
+#
+#
+# class A:
+#     def __init__(self, l):
+#         self._l = l
+#
+#
+# a = A([1,'k',2,'q', 'l', 3])
+# b = A(('a',10,'b',11,'c'))
+# k = TypeIterator(ParentIterator(a), str)
+# for i in k:
+#     print(i)
+#     if i == 'k':
+#         k(b)
+#
+#     # k(b)
+#     # for i in k:
+#     #     print(i)
+# print(callable(TypeIterator))
+
+l = [1,2,3,'k','s',4,'d',5]
+
+def a(iterable):
+    for i in iterable:
+        yield i
+
+def b(iterable, typ):
+    for i in iterable:
+        if isinstance(i, typ):
+            yield i
+
+def it(self, iterable):
+    for i in iterable(self):
+        yield i
+
+for i in a(l):
+    print(i)
+print()
+for i in b(l, str):
+    print(i)
+print()
+
+for i in it(l, b(a, int)):
+    print(i)

--- a/etc/python/new generator from used generator.py
+++ b/etc/python/new generator from used generator.py
@@ -1,0 +1,8 @@
+l = [1,2,3,4]
+a = (i+i for i in l)
+print(a)
+for i in a:
+    print(i)
+a.
+for i in a:
+    print(a)

--- a/etc/python/singleton.py
+++ b/etc/python/singleton.py
@@ -1,0 +1,27 @@
+"""
+Singleton class example
+"""
+
+class SingletonClass:
+    _instance = None
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            ins = super().__new__(cls)
+            cls._instance = ins
+            return ins
+
+        if '__init__' in cls._instance.__class__.__dict__:
+            delattr(cls._instance.__class__, '__init__')
+        return cls._instance
+
+
+class A(SingletonClass):
+
+    def __init__(self):
+        print('initiation A')
+    pass
+
+a = A()
+b = A()
+c = A()
+print(a, b, c)

--- a/etc/ref or proxy.py
+++ b/etc/ref or proxy.py
@@ -1,0 +1,15 @@
+import weakref as wr
+
+class A:
+    def __init__(self):
+        self.v = 10
+a = A()
+
+b = wr.ref(a)
+c = wr.proxy(a)
+# print(a, a.v)
+# print(b, b().v)
+# print(c, c.v)
+del a
+print(b)
+print(c())

--- a/etc/scrible.py
+++ b/etc/scrible.py
@@ -1,0 +1,29 @@
+class FooType(type):
+    def _foo_func(cls):
+        return 'foo!'
+
+    def _bar_func(cls):
+        return 'bar!'
+
+    def __getattr__(cls, key):
+        if key == 'Foo':
+            return cls._foo_func()
+        elif key == 'Bar':
+            return cls._bar_func()
+        raise AttributeError(key)
+
+    def __str__(cls):
+        return 'custom str for %s' % (cls.__name__,)
+
+class MyClass(metaclass=FooType):
+    # __metaclass__ = FooType
+    pass
+
+# in python 3:
+# class MyClass(metaclass=FooType):
+#    pass
+
+
+print(MyClass.Foo)
+print(MyClass.Bar)
+print(str(MyClass))

--- a/etc/structured numpy array.py
+++ b/etc/structured numpy array.py
@@ -1,0 +1,36 @@
+import numpy as np
+from collections import namedtuple
+
+
+print(np.float64.dtype, type(np.float64))
+print(np.dtype(np.float32))
+
+# building array with single field with multiple values
+values = [[1,2,3], [4,5,6], [7,8,9]]
+values = [tuple([tuple(chunk)]) for chunk in values]
+print(values)
+dtype = np.dtype([('coord', 'f', 3)])
+arr = np.array(values, dtype=dtype)
+print(arr, '\n')
+
+# adding new row to it
+row = np.array(([10,11,12],), dtype=dtype)
+arr = np.append(arr, row)
+print(arr,'\n')
+
+# checking itemsize
+print(arr.itemsize) # item size of a row
+print('total byte', arr.itemsize*arr.size)
+print(arr['coord'].itemsize)    # item size of a single element
+
+d = np.dtype([('a', 'f8', 3), ('b', 'f', 2), ('c', 'f', 3)])
+
+nt = namedtuple('vao_properties', ('name', 'size', 'type', 'stride', 'offset'))
+nts = []
+stride = 10
+for k, v in d.fields.items():
+    dtype, offset = v
+    subdtype, size = dtype.subdtype
+    size = size[0]
+    print(subdtype)
+    print(nt(k, size, subdtype, stride, offset))

--- a/etc/transformatioin into array.py
+++ b/etc/transformatioin into array.py
@@ -1,0 +1,9 @@
+from gkernel.dtype.geometric.primitive import Pnt, Vec, Pln
+import numpy as np
+
+pln = Pln((100, 100, 100),
+          (-0.7, 0.7, 0),
+          (-0.5, -0.5, 0.68),
+          (0.48, 0.48, 0.72))
+
+pnt = Pnt(10, 10, 10)

--- a/etc/view/main.py
+++ b/etc/view/main.py
@@ -1,0 +1,40 @@
+from gkernel.dtype.geometric.primitive import Pnt, Tgl
+from mkernel.model import *
+from wkernel import Window
+
+
+# from gkernel.dtype.geometric.complex import
+
+class W(Window):
+    def __init__(self):
+        super().__init__(500, 300, 'window1')
+
+    def setup(self):
+        print('setting up')
+        self.framerate = 2
+        self.panes.new_pane(0.25, 0.25, 0.5, 0.5)
+        # self.views.new_view(0, 0, 0.5, 0.5)
+        self.cameras[0].tripod.lookat((100, 100, 100), (0, 0, 0), (0, 0, 1))
+        # self.cameras[0].set_fps_dolly(self)
+
+    def draw(self):
+        super().draw()
+
+        with self.panes[1] as v:
+            v.clear(0, 1, 0.5, 1)
+            with self.cameras[0] as c:
+                print()
+                print(self.devices.mouse.cursor_in_view(v))
+                print(self.cameras[0].tripod.plane.r.origin)
+                print(self.cameras[0].body.PM.r * self.cameras[0].tripod.VM.r * Pnt(0, 0))
+                a = 100
+                model = Model()
+                model.append_shape(Tgl((0, 0, 0), (a, 0, 0), (0, a, 0)))
+                model.append_shape(Tgl((0, 0, 0), (-a, 0, 0), (0, -a, 0)))
+                model.append_shape(Tgl((a, a, 0), (a, 0, 0), (0, a, 0)))
+                self.devices.mouse.intersect_model(v, c, model)
+
+
+
+w = W()
+w.run_all()

--- a/etc/wrapper.py
+++ b/etc/wrapper.py
@@ -1,0 +1,14 @@
+
+dd = 10
+def a(obj):
+    def wrapper():
+        l = 10
+        print(l)
+        obj()
+    return wrapper
+
+@a
+def kk():
+    pass
+print(kk)
+kk()

--- a/src/ckernel/render_context/opengl_context/bffr_cache.py
+++ b/src/ckernel/render_context/opengl_context/bffr_cache.py
@@ -124,6 +124,7 @@ class BffrCache(ArrayContainer):
         :param reset_val: value to fill released block with
         :return:
         """
+
         if block not in self.__block_inuse:
             raise ValueError('block not of this cache, please access via block.release()')
         # stop tracking
@@ -160,9 +161,11 @@ class BffrCache(ArrayContainer):
         :param reset_val: value to fill into released vertex
         :return: mapping info tuple((from indices...), (to indices...))
         """
+
         # size can differ, last can be bigger than to fill and smaller or equal
         if self.__block_pool[0][0] < self.highest_indx:  # cant be equal
-            src_block = self.__block_inuse.pop()
+            src_block = self.__block_inuse[-1]
+            self._release_block(src_block)
             src_idxs = src_block.indices
             src_size = len(src_idxs)
             # collect indicies
@@ -196,13 +199,13 @@ class BffrCache(ArrayContainer):
         return self.__array
 
     @property
-    def bytesize(self):
+    def active_bytesize(self):
         """
         size of whole array in bytes
 
         :return:
         """
-        return self.__array.size * self.__array.itemsize
+        return self.highest_indx  * self.__array.itemsize
 
     @property
     def gldtype(self):

--- a/src/ckernel/render_context/opengl_context/ogl_entities.py
+++ b/src/ckernel/render_context/opengl_context/ogl_entities.py
@@ -252,7 +252,7 @@ class _Bffr(OGLEntity):
 
         with self as bffr:
             gl.glBufferData(target=bffr.__target,
-                            size=self.__cache.bytesize,
+                            size=self.__cache.active_bytesize,
                             data=self.__cache.array,
                             usage=bffr.__usage)
             # unbinding needed? does vao affected by vbo binding before its binding?

--- a/src/global_tools/skip_list.py
+++ b/src/global_tools/skip_list.py
@@ -26,7 +26,7 @@ class SkipList:
         :param item: item to search for
         :return:
         """
-        node = self.__search_bisect_left(item, return_path=False)
+        node = self.__search_bisect_left(item, return_path=False).get_right(level=0)[0]
         for nn, _ in node.iter_level(level=0):
             if self.__key_provider(nn.val) <= self.__key_provider(item):
                 if nn.val is item:
@@ -41,7 +41,6 @@ class SkipList:
     def __getitem__(self, item):
         """
         binary searching by width
-
         1. move right untile steps are too big
         2. go down
         3. repeat from 1

--- a/src/wkernel/pipeline/nodes/opengl/primitive/buffer_nodes.py
+++ b/src/wkernel/pipeline/nodes/opengl/primitive/buffer_nodes.py
@@ -58,7 +58,7 @@ class PushBufferData(BufferComponent):
     def calculate(self, bffr, data):
         gl.glBindBuffer(bffr.kind, bffr.id)
         gl.glBufferData(bffr.kind,
-                        data.bytesize,
+                        data.active_bytesize,
                         data.data,
                         gl.GL_STATIC_DRAW)
         return DataBufferObject(bffr, data)


### PR DESCRIPTION
benchmark index deactivation mechanisms
    Index tight packing reduces number of indices to render but packing itself takes too much time. Therefore release_fill operation is not fast enough to be executed commonly in frame-time.
    It is meaningful only if done asynchronously against render thread, when cache is not in use.
    resolve #63
    resolve #64

bugfix `SkipList` membership test

bugfix 'BffrCache' refillling

bugfix old benchmarks
    Was measuring CPU elapse time. Fixed to measure GPU elapse time