### PR TITLE
pyopengl2-74 implement `BffrCache` overflow operation

### DIFF
--- a/run/render overflow pnts.py
+++ b/run/render overflow pnts.py
@@ -1,0 +1,37 @@
+from doodler import *
+from mkernel import Model, Tgl
+from wkernel import Window
+import gkernel.dtype.geometric as gt
+from gkernel.color import *
+
+
+class MyWindow(Window):
+    def __init__(self):
+        super().__init__(1000, 1000, 'my window 1', monitor=None, shared=None)
+        self.framerate = 60
+        # enable camera move
+        o = 200
+        # self.devices.cameras[0].tripod.lookat(eye=(0, 0, o), at=(0, 0, 0), up=(0, 1, 0))
+        self.devices.cameras[0].focus_pane(pane=self.devices.panes[0], focus=(0, 0, 0), clip_off=100)
+
+        # create model
+        model1 = Model()
+        self.model1 = model1
+        pw, ph = self.devices.panes[0].size
+        n = 20
+        nw, nh = pw//n, ph//n
+        for x in range(-pw//2+nw, pw//2-nw+1, nw):
+            for y in range(-ph//2+nh, ph//2-nh+1, nh):
+                p = model1.add_pnt(x, y, 0)
+                p.frm = p.FORM_CIRCLE
+                p.dia = 10
+
+
+    def draw(self, frame_count=None):
+        with self.devices.panes[0] as p:
+            with self.devices.cameras[0] as c:
+                p.clear(.5, .5, .5, 1)
+                # e = 100
+                self.model1.render()
+
+MyWindow().run_all(1)

--- a/src/ckernel/render_context/opengl_context/bffr_cache.py
+++ b/src/ckernel/render_context/opengl_context/bffr_cache.py
@@ -65,11 +65,16 @@ class BffrCache(ArrayContainer):
 
     def __expand_array(self):
         """
-        double the size of the array
+        in case of overflow double the size of the array
 
         :return:
         """
-        raise NotImplementedError
+        old_len = len(self.__array)
+        new_len = old_len * 2
+        new_arr = np.ndarray(shape=new_len, dtype=self.__array.dtype)
+        new_arr[:old_len] = self.__array
+        self.__block_pool.append((old_len, new_len))
+        self.__array = new_arr
 
     @property
     def active_size(self):
@@ -95,7 +100,7 @@ class BffrCache(ArrayContainer):
         indices = []
         while 0 < size:
             if not self.__block_pool:
-                raise NotImplementedError('overflow')
+                self.__expand_array()
 
             s, e = self.__block_pool[0]
             vacant_size = e - s

--- a/src/gkernel/dtype/geometric/primitive.py
+++ b/src/gkernel/dtype/geometric/primitive.py
@@ -841,6 +841,15 @@ class Pln(ArrayLikeData, PntConv):
             return True
         return False
 
+    def orient(self, obj):
+        """
+        orient given geometric object to this plane
+
+        :param obj:
+        :return:
+        """
+        return self.TM * obj
+
     def get_axis(self, sign: ('x', 'y', 'z')):
         sign = {'x': 1, 'y': 2, 'z': 3}[sign]
         v = Vec.from_row(self._data[:, sign:sign + 1])


### PR DESCRIPTION
implement `BffrCache.__expand_array`
    Turned out to be very simple as Blocks were refering cache not array in it. Shrink is another story but that implementation is not urgent.