### PR TITLE
pyopengl2-101 implement horizon

### DIFF
--- a/run/color picking.py
+++ b/run/color picking.py
@@ -16,10 +16,10 @@ class MainWindow(Window):
         ffactory.set_size(w, h)
         ffactory.append_texture(target=ffactory.TEXTURE.TARGET.TWO_D,
                                 format=ffactory.TEXTURE.FORMAT.RGBA,
-                                attachment_loc=0)
+                                tid=0)
         ffactory.append_texture(target=ffactory.TEXTURE.TARGET.TWO_D,
                                 format=ffactory.TEXTURE.FORMAT.RGB,
-                                attachment_loc=1)
+                                tid=1)
         ffactory.set_render_buffer(format=ffactory.RENDER.DEPTH_STENCIL.D24_S8,
                                    attachment_loc=None)
         ffactory.create()
@@ -60,7 +60,7 @@ class MainWindow(Window):
             self.devices.frames[1].render_pane_space(0, (-1, 1), (-1, 1), 0.9, (0, 1), (0, 1))
             with self.devices.frames[1] as f:
                 pos = p.cursor_pos(parameterize=True)
-                c = f.pick_texture(aid=1, pos=pos, parameterized=True).as_byte
+                c = f.pick_texture(tid=1, pos=pos, parameterized=True).as_byte
                 e = GlobalColorRegistry().get_registered(tuple(c))
                 print(e)
 

--- a/run/render frame buffer.py
+++ b/run/render frame buffer.py
@@ -14,10 +14,10 @@ class MainWindow(Window):
         ffactory.set_size(w, h)
         ffactory.append_texture(target=ffactory.TEXTURE.TARGET.TWO_D,
                                 format=ffactory.TEXTURE.FORMAT.RGBA,
-                                attachment_loc=0)
+                                tid=0)
         ffactory.append_texture(target=ffactory.TEXTURE.TARGET.TWO_D,
                                 format=ffactory.TEXTURE.FORMAT.RGB,
-                                attachment_loc=1)
+                                tid=1)
         ffactory.set_render_buffer(format=ffactory.RENDER.DEPTH_STENCIL.D24_S8,
                                    attachment_loc=None)
         ffactory.create()

--- a/run/render ground.py
+++ b/run/render ground.py
@@ -1,0 +1,111 @@
+from wkernel import Window
+from mkernel import Model
+from mkernel.color_registry import GlobalColorRegistry
+import gkernel.color as clr
+from akernel.environmental.ground import Ground
+import time
+
+
+class MainWindow(Window):
+    def __init__(self):
+        super().__init__(800, 1000, 'mywindow')
+        self.framerate = 5
+        # want to create frame
+        w, h = self.glyph.size
+        ffactory = self.devices.frames.factory
+        ffactory.set_size(w, h)
+        ffactory.append_color_texture(target=ffactory.TEXTURE.TARGET.TWO_D,
+                                      format=ffactory.TEXTURE.FORMAT.RGBA,
+                                      loc=0)
+        ffactory.append_color_texture(target=ffactory.TEXTURE.TARGET.TWO_D,
+                                      format=ffactory.TEXTURE.FORMAT.RGB,
+                                      loc=1)  # color id texture
+        ffactory.append_depth_texture(target=ffactory.TEXTURE.TARGET.TWO_D,
+                                      format=ffactory.TEXTURE.FORMAT.DEPTH_COMPONENT)
+        # ffactory.set_render_buffer(format=ffactory.RENDER.DEPTH_STENCIL.D24_S8,
+        #                            attachment_loc=None)
+        ffactory.create()
+
+        # create pane
+        self.devices.panes.appendnew_pane(0.1, 0.1, 0.6, 0.6, self)
+
+        # set camera
+        self.devices.cameras[0].tripod.lookat(eye=(100, 50, 30), at=(0, 0, 0), up=(0, 0, 1))
+
+        # draw something
+        model = Model()
+
+        for x in range(3):
+            for y in range(3):
+                p = model.add_pnt(x*20, y*20, 0)
+                p.dia = 5
+                p.clr = 1, 0, 0, 1
+                p.frm = p.FORM_CIRCLE
+
+        p1 = model.add_pnt(12, 12, 12)
+        p1.dia = 5
+        p1.clr = 1, 0, 0, 1
+        p1.frm = p1.FORM_CIRCLE
+
+        p2 = model.add_pnt(10, 10, 10)
+        p2.dia = 5
+        p2.clr = 1, 1, 0, 1
+        p2.frm = p2.FORM_TRIANGLE
+
+        p3 = model.add_pnt(80, 30, 0)
+        p3.dia = 5
+        p3.clr = 1, 1, 1, 1
+        p3.frm = p3.FORM_TRIANGLE
+
+        self.model = model
+        self.is_rendered = False
+        self.ground = Ground(clr.ClrRGBA(.8, .8, .8, 1))
+
+    def draw(self):
+        with self.devices.frames[0] as deff:
+            deff.clear(0, 0, 0, 1)
+            deff.clear_depth()
+        with self.devices.cameras[0] as cam:
+            if not self.is_rendered:
+                with self.devices.frames[1] as f:
+                    f.clear_depth()
+                    f.clear_texture(0, .5, .5, .5, 1)
+                    f.clear_texture(1, 0, 0, 0, 1)
+                    self.model.render()
+                    self.is_rendered = True
+
+        with self.devices.panes[1] as p:
+            self.ground.render(cam)
+            self.devices.frames[1].render_pane_space_depth(0, (0, 1, 0, 1), (-1, 1, -1, 1))
+            # self.devices.frames[1].render_pane_space(0, (0, 1, 0, 1), (-1, 1, -1, 1), 0)
+            # with self.devices.frames[1] as deff:
+            #     pos = p.cursor_pos(parameterize=True)
+            #     c = deff.pick_texture(tid=1, pos=pos, parameterized=True).as_byte
+            #     e = GlobalColorRegistry().get_registered(tuple(c))
+
+
+class SubWindow(Window):
+    def __init__(self, mother):
+        super().__init__(500, 500, 'sub window', shared=mother)
+        self.ma = mother
+
+        self.devices.panes.appendnew_pane(0, 0, 0.5, 0.5, self)
+        self.devices.panes.appendnew_pane(0.5, 0, 0.5, 0.5, self)
+        self.devices.panes.appendnew_pane(0.5, 0.5, 0.5, 0.5, self)
+
+    def draw(self):
+        time.sleep(0.1)
+        with self.devices.frames[0] as f:
+            f.clear_depth()
+            if self.ma.is_rendered:
+                with self.devices.panes[1]:
+                    self.ma.devices.frames[1].render_pane_space(0, (0, 1, 0, 1), (-1, 1, -1, 1), 0)
+                with self.devices.panes[2]:
+                    self.ma.devices.frames[1].render_pane_space(1, (0, 1, 0, 1), (-1, 1, -1, 1), 0)
+                with self.devices.panes[3]:
+                        self.ma.devices.frames[1].render_pane_space('d', (0, 1, 0, 1), (-1, 1, -1, 1), 0)
+
+window_main = MainWindow()
+window_sub = SubWindow(window_main)
+
+window_main.run_all(1)

--- a/src/akernel/environmental/ground.py
+++ b/src/akernel/environmental/ground.py
@@ -1,0 +1,46 @@
+import os
+import ckernel.render_context.opengl_context.meta_entities as meta
+from ckernel.render_context.opengl_context.context_stack import get_current_ogl
+import OpenGL.GL as gl
+
+
+class Ground:
+    """
+    draw infinite ground
+    """
+    __this_dir = os.path.dirname(__file__)
+    __prgrm = meta.MetaPrgrm(vrtx_path=os.path.join(__this_dir, 'ground_vrtx_shdr.glsl'),
+                             frgm_path=os.path.join(__this_dir, 'ground_frgm_shdr.glsl'))
+
+    def __init__(self, color):
+        self.__vbo = self.__prgrm.vrtxattr_schema.create_vrtx_bffr()
+        self.__vao = meta.MetaVrtxArry(self.__vbo)
+        self.__block = self.__vbo.cache.request_block(size=4)
+        l = 1
+        self.__block['pos'] = (-l, -l, 0), (l, -l, 0), (l, l, 0), (-l, l, 0)    # cover whole NDC
+
+        self.__color = color
+        self.__block['clr'] = color
+
+    @property
+    def clr(self):
+        return self.__color
+
+    @clr.setter
+    def clr(self, v):
+        self.__color = v
+        self.__block['clr'] = v
+
+    def render(self, camera):
+        # update camera properties
+        self.__block['near'] = camera.near_clipping_face[:3].T
+        self.__block['far'] = camera.far_clipping_face[:3].T
+        self.__vbo.push_cache()
+
+        self.__prgrm.uniforms['PM'] = camera.body.PM
+        self.__prgrm.uniforms['VM'] = camera.tripod.VM
+        self.__prgrm.push_uniforms()
+
+        with self.__prgrm:
+            with self.__vao:
+                gl.glDrawArrays(gl.GL_QUADS, 0, 4)

--- a/src/akernel/environmental/ground_frgm_shdr.glsl
+++ b/src/akernel/environmental/ground_frgm_shdr.glsl
@@ -1,0 +1,48 @@
+#version 450 core
+
+layout (location=0) uniform mat4 PM;
+layout (location=1) uniform mat4 VM;
+//layout (location=1) uniform mat4 MM = mat4(1.0);
+
+in vec3 fpos;
+in vec3 fnear;
+in vec3 ffar;
+in vec4 fclr;
+
+layout (location=0) out vec4 clr;
+
+float compute_depth(vec3 P) {
+    vec4 ndc_p = PM * VM * vec4(P, 1);
+    float depth = ndc_p.z/ndc_p.w;
+    float f = gl_DepthRange.far;
+    float n = gl_DepthRange.near;
+    float d = gl_DepthRange.diff;
+    depth = n + (f - n) * (depth + 1)/2.0;
+    return depth;
+}
+
+void main() {
+    // reference:
+    // https://github.com/martin-pr/possumwood/wiki/Infinite-ground-plane-using-GLSL-shaders
+    // for each pixel find ray amplifier t where y is 0
+    // this tells ray intersecting ground
+    // 0 = near + t*(far - near)
+    vec3 ray = (ffar - fnear);
+    float r = -fnear.z / ray.z;
+    vec3 P = fnear + r*ray;// intersection Point
+
+    float ps = 1./10.;// chess pattern size
+    // clamping resulted to 0.3 ~ 1
+    float c = int(round(P.x * ps) + round(P.y * ps)) % 2;
+    c = c*0.5 + 0.5;
+
+    // soft horizon; use distance from camera near on xy
+    float d = distance(fnear.xy, P.xy);
+    float t0 = 100.;
+    float t1 = 1000.;
+    float l = max(0, min(1., (t1-d)/(t1-t0)));
+    if (r < 0) discard;// negative t means ground is behind camera; meaning sky
+    // blending rgb
+    clr = vec4(fclr.xyz * c * l, 1);
+    gl_FragDepth = compute_depth(P);
+}

--- a/src/akernel/environmental/ground_vrtx_shdr.glsl
+++ b/src/akernel/environmental/ground_vrtx_shdr.glsl
@@ -1,0 +1,18 @@
+#version 450 core
+
+layout (location=0) in vec3 pos;
+layout (location=1) in vec3 near;
+layout (location=2) in vec3 far;
+layout (location=3) in vec4 clr;
+
+out vec3 fpos;
+out vec3 fnear;
+out vec3 ffar;
+out vec4 fclr;
+
+void main() {
+    fnear = near;
+    ffar = far;
+    fclr = clr;
+    gl_Position = vec4(pos, 1);
+}

--- a/src/ckernel/render_context/opengl_context/bffr_cache.py
+++ b/src/ckernel/render_context/opengl_context/bffr_cache.py
@@ -251,7 +251,10 @@ class BffrCache(ArrayContainer):
         ntuple = namedtuple('interleave_prop', 'name, loc, size, dtype, stride, offset')
         stride = self.array.itemsize
         for name, (dtype, offset) in self.__array.dtype.fields.items():
-            dtype, shape = dtype.subdtype
+            if dtype.subdtype is not None:
+                dtype, shape = dtype.subdtype
+            else:
+                shape = (1, )
             loc = self.__locs[name]
             tuples.append(ntuple(name, loc, shape, dtype, stride, offset))
         return tuple(tuples)

--- a/src/ckernel/render_context/opengl_context/constant_enum.py
+++ b/src/ckernel/render_context/opengl_context/constant_enum.py
@@ -2,9 +2,49 @@ from global_tools.enum import enum
 import ckernel.render_context.opengl_context.opengl_hooker as gl
 
 
-class RenderBufferTarget:
+class DrawBufferFormats:
+    @enum
+    class COLOR:
+        RED = enum.prop(gl.GL_RED)
+        RG = enum.prop(gl.GL_RG)
+        RGB = enum.prop(gl.GL_RGB)
+        RGBA = enum.prop(gl.GL_RGBA)
+        # ATTACHMENT0 = enum.prop(gl.GL_COLOR_ATTACHMENT0)
+        # ATTACHMENT1 = enum.prop(gl.GL_COLOR_ATTACHMENT1)
+        # ATTACHMENT2 = enum.prop(gl.GL_COLOR_ATTACHMENT2)
+        # ATTACHMENT3 = enum.prop(gl.GL_COLOR_ATTACHMENT3)
+        # ATTACHMENT4 = enum.prop(gl.GL_COLOR_ATTACHMENT4)
+        # ATTACHMENT5 = enum.prop(gl.GL_COLOR_ATTACHMENT5)
+        # ATTACHMENT6 = enum.prop(gl.GL_COLOR_ATTACHMENT6)
+        # ATTACHMENT7 = enum.prop(gl.GL_COLOR_ATTACHMENT7)
+        # ATTACHMENT8 = enum.prop(gl.GL_COLOR_ATTACHMENT8)
+        # ATTACHMENT9 = enum.prop(gl.GL_COLOR_ATTACHMENT9)
+        # ATTACHMENT10 = enum.prop(gl.GL_COLOR_ATTACHMENT10)
+        # ATTACHMENT11 = enum.prop(gl.GL_COLOR_ATTACHMENT11)
+        # ATTACHMENT12 = enum.prop(gl.GL_COLOR_ATTACHMENT12)
+        # ATTACHMENT13 = enum.prop(gl.GL_COLOR_ATTACHMENT13)
+        # ATTACHMENT14 = enum.prop(gl.GL_COLOR_ATTACHMENT14)
+        # ATTACHMENT15 = enum.prop(gl.GL_COLOR_ATTACHMENT15)
+        # ATTACHMENT16 = enum.prop(gl.GL_COLOR_ATTACHMENT16)
+        # ATTACHMENT17 = enum.prop(gl.GL_COLOR_ATTACHMENT17)
+        # ATTACHMENT18 = enum.prop(gl.GL_COLOR_ATTACHMENT18)
+        # ATTACHMENT19 = enum.prop(gl.GL_COLOR_ATTACHMENT19)
+        # ATTACHMENT20 = enum.prop(gl.GL_COLOR_ATTACHMENT20)
+        # ATTACHMENT21 = enum.prop(gl.GL_COLOR_ATTACHMENT21)
+        # ATTACHMENT22 = enum.prop(gl.GL_COLOR_ATTACHMENT22)
+        # ATTACHMENT23 = enum.prop(gl.GL_COLOR_ATTACHMENT23)
+        # ATTACHMENT24 = enum.prop(gl.GL_COLOR_ATTACHMENT24)
+        # ATTACHMENT25 = enum.prop(gl.GL_COLOR_ATTACHMENT25)
+        # ATTACHMENT26 = enum.prop(gl.GL_COLOR_ATTACHMENT26)
+        # ATTACHMENT27 = enum.prop(gl.GL_COLOR_ATTACHMENT27)
+        # ATTACHMENT28 = enum.prop(gl.GL_COLOR_ATTACHMENT28)
+        # ATTACHMENT29 = enum.prop(gl.GL_COLOR_ATTACHMENT29)
+        # ATTACHMENT30 = enum.prop(gl.GL_COLOR_ATTACHMENT30)
+        # ATTACHMENT31 = enum.prop(gl.GL_COLOR_ATTACHMENT31)
+
     @enum
     class DEPTH:
+        BASE = enum.prop(gl.GL_DEPTH_COMPONENT)
         D16 = enum.prop(gl.GL_DEPTH_COMPONENT16)
         D24 = enum.prop(gl.GL_DEPTH_COMPONENT24)
         D32F = enum.prop(gl.GL_DEPTH_COMPONENT32F)

--- a/src/ckernel/render_context/opengl_context/meta_entities/frame_buffer.py
+++ b/src/ckernel/render_context/opengl_context/meta_entities/frame_buffer.py
@@ -1,39 +1,35 @@
 from .base import OGLMetaEntity
 import ckernel.render_context.opengl_context.opengl_hooker as gl
 from .texture import MetaTexture
-from ..constant_enum import RenderBufferTarget
+from ..constant_enum import DrawBufferFormats
 
 
 class MetaFrameBffr(OGLMetaEntity):
 
-    def __init__(self, *attachments, locs):
+    def __init__(self, *attachments, tids):
         """
 
         :param attachments: MetaTexture or MetaRenderBffr
-        :param locs: (int, ...) indx value that will be translated into GL_COLOR_ATTACHMENT{indx}
+        :param tids: int or str, semantic texture ids
+                    integer - color attachment
+                    'd','ds' - depth and depth-stencil
         """
-        if len(attachments) != len(locs):
+        for a in attachments:
+            if not isinstance(a, (MetaTexture, MetaRenderBffr)):
+                raise TypeError
+        if len(attachments) != len(tids):
             raise Exception('all locations for attachment has to be given, for that does not have location set `None`')
-
-        __locs = set()
-        self.__textures = {}
-        self.__render_buffer = []
-        for a, l in zip(attachments, locs):
-            if l is not None:
-                if l in __locs:
-                    raise ValueError('attachment location value has to be unique')
-                else:
-                    __locs.add(l)
-            if isinstance(a, MetaTexture):
-                self.__textures[l] = a
-            elif isinstance(a, MetaRenderBffr):
-                self.__render_buffer.append((a, l))
-            else:
+        if len(set(tids)) != len(tids):
+            raise ValueError('texture ids has to be unique')
+        for tid in tids:
+            if isinstance(tid, str):
+                if tid not in ('d', 'ds'):
+                    raise ValueError
+            elif not isinstance(tid, int):
                 raise TypeError
 
-        self.__color_attachment_locs = []
-        for i in __locs:
-            self.__color_attachment_locs.append(eval(f"gl.GL_COLOR_ATTACHMENT{i}"))
+        self.__attachments = {t: a for a, t in zip(attachments, tids)}
+        self.__color_attachment_locs = [eval(f"gl.GL_COLOR_ATTACHMENT{i}") for i in tids if isinstance(i, int)]
 
     def __str__(self):
         return f"<MetaFrameBffr >"
@@ -48,55 +44,66 @@ class MetaFrameBffr(OGLMetaEntity):
         return self.__textures[0].size
 
     def _create_entity(self):
-        if not (self.__textures or self.__render_buffer):
+        if not self.__attachments:
             raise ValueError('not enough properties given')
 
         fb = gl.glGenFramebuffers(1, gl.GL_FRAMEBUFFER)
         fb.set_target(gl.GL_FRAMEBUFFER)
         with fb:
-            # deal with textures
-            # ! give attantion to how attachment index is given
-            for i, texture in self.__textures.items():
-                if texture.target == gl.GL_TEXTURE_2D:
-                    gl.glFramebufferTexture2D(gl.GL_FRAMEBUFFER,  # target
-                                              eval(f"gl.GL_COLOR_ATTACHMENT{i}"),  # attachment
-                                              texture.target,  # textarget
-                                              texture.get_concrete(),  # texture
-                                              0)  # level
-                else:
-                    raise NotImplementedError
+            for tid, att in self.__attachments.items():
+                if isinstance(att, MetaTexture):
+                    # deal with textures
+                    if att.target == gl.GL_TEXTURE_2D:
+                        # find attachment
+                        if att.iformat in DrawBufferFormats.COLOR:
+                            attachment = eval(f'gl.GL_COLOR_ATTACHMENT{tid}')
+                        else:
+                            attachment = self.__iformat_to_attachment(att.iformat)
 
-            for rb, i in self.__render_buffer:
-                if gl.GL_COLOR_ATTACHMENT0 <= rb.iformat <= gl.GL_COLOR_ATTACHMENT31:
-                    if i is None:
-                        raise ValueError('color attachment location for frame buffer not given')
+                        gl.glFramebufferTexture2D(gl.GL_FRAMEBUFFER,  # target
+                                                  attachment,  # attachment
+                                                  att.target,  # textarget
+                                                  att.get_concrete(),  # texture
+                                                  0)  # level
+                    else:
+                        raise NotImplementedError
                 else:
-                    if i is not None:
-                        raise ValueError('given location cant be resolved')
-                    gl.glFramebufferRenderbuffer(gl.GL_FRAMEBUFFER,  # target
-                                                 self.__iformat_to_attachment(rb.iformat),  # attachment
-                                                 gl.GL_RENDERBUFFER,  # renderbuffertarget
-                                                 rb.get_concrete())  # renderbuffer
+                    if gl.GL_COLOR_ATTACHMENT0 <= att.iformat <= gl.GL_COLOR_ATTACHMENT31:
+                        if tid is None:
+                            raise ValueError('color attachment location for frame buffer not given')
+                    else:
+                        if tid is not None:
+                            raise ValueError('given location cant be resolved')
+                        gl.glFramebufferRenderbuffer(gl.GL_FRAMEBUFFER,  # target
+                                                     self.__iformat_to_attachment(att.iformat),  # attachment
+                                                     gl.GL_RENDERBUFFER,  # renderbuffertarget
+                                                     att.get_concrete())  # renderbuffer
             # check texture binding
             if gl.glCheckFramebufferStatus(gl.GL_FRAMEBUFFER) != gl.GL_FRAMEBUFFER_COMPLETE:
                 raise Exception('FrameBuffer linking error')
 
         return fb
 
-    def __iformat_to_attachment(self, iformat):
-        if iformat in RenderBufferTarget.DEPTH_STENCIL:
+    @staticmethod
+    def __iformat_to_attachment(iformat):
+        if iformat in DrawBufferFormats.DEPTH:
+            return gl.GL_DEPTH_ATTACHMENT
+        elif iformat in DrawBufferFormats.DEPTH_STENCIL:
             return gl.GL_DEPTH_STENCIL_ATTACHMENT
         else:
             raise TypeError
 
-    def get_texture_attachment(self, idx) -> MetaTexture:
+    def get_texture_attachment(self, tid) -> MetaTexture:
         """
         return texture of given color attachment
 
-        :param idx:
+        :param tid: texture id, e.g.
+                    0, 1 - integers for color attachment
+                    'd' - depth attachment
+                    'ds' - depth stencil attachment
         :return:
         """
-        return self.__textures[idx]
+        return self.__attachments[tid]
 
     def bind(self):
         """

--- a/src/ckernel/render_context/opengl_context/meta_entities/prgrm/base.py
+++ b/src/ckernel/render_context/opengl_context/meta_entities/prgrm/base.py
@@ -165,7 +165,6 @@ class MetaPrgrm(OGLMetaEntity):
             t = 'i'
         else:
             raise NotImplementedError
-
         return eval(f"gl.glUniform{m}{d}{t}v")
 
     # attachers

--- a/src/ckernel/render_context/opengl_context/meta_entities/prgrm/schemas.py
+++ b/src/ckernel/render_context/opengl_context/meta_entities/prgrm/schemas.py
@@ -5,6 +5,7 @@ Schemas describes data structure of shader parameters
 and has methods for creating buffer cache.
 """
 
+
 class _GLSLParamSchema:
     @property
     def dtype(self):
@@ -65,5 +66,6 @@ class UfrmSchema(_GLSLParamSchema):
         """
         cache = BffrCache(self._dtype, self._locs, size)
         for name, val in zip(self._dtype.fields, self._def_val):
-            cache.array[name][...] = val
+            if val is not None:
+                cache.array[name][...] = val
         return cache

--- a/src/ckernel/render_context/opengl_context/meta_entities/prgrm/shdr_parser.py
+++ b/src/ckernel/render_context/opengl_context/meta_entities/prgrm/shdr_parser.py
@@ -141,31 +141,32 @@ class SimpleShdrParser:
             for m in re.finditer(cls.__layout_ufrm_patt, src):
                 # check layout declaration
                 d = m.groupdict()
-                if d['dtype'] == 'sampler2D':
-                    pass
-                else:
-                    if d['layout'] is None:
-                        raise SyntaxError(f"{m.group()} <- uniform's layout not declared")
 
-                    # location
-                    loc = int(d['loc'])
-                    pair = (d['name'], loc)
-                    for u in unique:
-                        if sum([i == j for i, j in zip(pair, u)]) == 1: # XOR
-                            raise ValueError('location values has to be unique')
-                    unique.add(pair)
+                # check location declaration
+                if d['layout'] is None:
+                    raise SyntaxError(f"{m.group()} <- uniform's layout not declared")
 
-                    # value
-                    if d['val'] is not None:
-                        val = eval(d['val'])
-                    else:
-                        val = None
+                # check uniquness
+                loc = int(d['loc'])
+                pair = (d['name'], loc)
+                for u in unique:
+                    if sum([i == j for i, j in zip(pair, u)]) == 1:  # XOR
+                        raise ValueError('location and att_name has to be unique')
+                unique.add(pair)
 
-                    # attribute
-                    dtype = cls.__translate_dtype(d['name'], d['dtype'])
-                    if d['name'] in args and args[d['name']] != (loc, val, dtype):
-                        raise Exception('attribute contradictory')
-                    args[d['name']] = (loc, val, dtype)
+                # def val needs additional parsing
+                # value
+                # if d['val'] is not None:
+                #     val = eval(d['val'])
+                # else:
+                #     val = None
+                val = None
+
+                # attribute
+                dtype = cls.__translate_dtype(d['name'], d['dtype'])
+                if d['name'] in args and args[d['name']] != (loc, val, dtype):
+                    raise Exception('attribute contradictory')
+                args[d['name']] = (loc, val, dtype)
 
         if args:
             # align by layout location
@@ -175,50 +176,44 @@ class SimpleShdrParser:
         else:
             return None
 
+    __singular_types = {'sampler': 'int32',
+                        'bool': 'bool',
+                        'int': 'int32',
+                        'uint': 'uint32',
+                        'float': 'float32',
+                        'double': 'float64'}
+
     @classmethod
     def __translate_dtype(cls, name, dtype):
         """
         translate glsl dtype into numpy dtype field
 
         :param dtype: str, glsl dtype
-        :return: (name, dtype, shape), numpy dtype field-like
+        :return: (name, dtype, shape), numpy dtype field description
         """
-        dtype, shape = re.match(cls.__dtype_patt, dtype).groups()
-        if shape is None:
-            if dtype == 'bool':
-                dtype = 'bool'
-            elif dtype == 'int':
-                dtype = 'int'
-            elif dtype == 'uint':
-                dtype = 'uint'
-            elif dtype == 'float':
-                dtype = 'f4'
-            elif dtype == 'double':
-                dtype = 'f8'
+        suf, pref = re.match(cls.__dtype_patt, dtype).groups()
+        if suf in cls.__singular_types: # singular types
+            return name, cls.__singular_types[suf]
+        elif pref is not None:  # complex types
+            pref = list(map(lambda x: int(x), pref.split('x')))
+            if suf == 'vec':  # vector types
+                if suf.startswith('d'):
+                    suf = 'float64'
+                elif suf.startswith('i'):
+                    suf = 'int'
+                elif suf.startswith('u'):
+                    suf = 'uint'
+                else:
+                    suf = 'float32'
+                pref = pref[0]
+            elif suf == 'mat':  # matrix types
+                if suf.startswith('d'):
+                    suf = 'float64'
+                else:
+                    suf = 'float32'
+                pref = tuple(pref*2) if len(pref) == 1 else tuple(pref)
             else:
-                raise TypeError
-            shape = (1,)
+                raise NotImplementedError(name, suf)
+            return name, suf, pref
         else:
-            shape = shape.replace('x', ',')
-            if 'vec' in dtype:
-                if dtype.startswith('d'):
-                    dtype = 'f8'
-                elif dtype.startswith('i'):
-                    dtype = 'int'
-                elif dtype.startswith('u'):
-                    dtype = 'uint'
-                else:
-                    dtype = 'f4'
-                shape = int(shape)
-
-            elif 'mat' in dtype:
-                if dtype.startswith('d'):
-                    dtype = 'f8'
-                else:
-                    dtype = 'f4'
-                shape = eval(f"({shape}, {shape})" if len(shape) == 1 else f"({shape})")
-            else:
-                raise NotImplementedError(name, dtype)
-        # field description
-        return name, dtype, shape
-
+            raise NotImplementedError

--- a/src/ckernel/render_context/opengl_context/meta_entities/texture.py
+++ b/src/ckernel/render_context/opengl_context/meta_entities/texture.py
@@ -4,6 +4,13 @@ from global_tools.enum import enum
 
 
 class MetaTexture(OGLMetaEntity):
+    __base_iformats = (gl.GL_DEPTH_COMPONENT,
+                       gl.GL_DEPTH_STENCIL,
+                       gl.GL_RED,
+                       gl.GL_RG,
+                       gl.GL_RGB,
+                       gl.GL_RGBA)
+
     def __init__(self, target, iformat, width, height):
         self.__target = target
         self.__iformat = iformat
@@ -12,6 +19,7 @@ class MetaTexture(OGLMetaEntity):
 
     def __str__(self):
         return f"<MetaTexture: {self.__target}, {self.__iformat}>"
+
     @property
     def iformat(self):
         return self.__iformat
@@ -61,9 +69,29 @@ class MetaTexture(OGLMetaEntity):
 
         :return:
         """
-        if self.__iformat == gl.GL_RGB:
-            return gl.GL_RGB
-        elif self.__iformat == gl.GL_RGBA:
-            return gl.GL_RGBA
+        if self.__iformat in self.__base_iformats:
+            return self.__iformat
         else:
             raise NotImplementedError
+
+    def as_unit(self, unit):
+        """
+        instant unit setting
+
+        :param unit:
+        :return:
+        """
+        return _MetaTextureAsUnit(self, unit)
+
+
+class _MetaTextureAsUnit:
+    def __init__(self, mt, unit):
+        self.__mt = mt
+        self.__unit = unit
+
+    def __enter__(self):
+        gl.glActiveTexture(gl.GL_TEXTURE0 + self.__unit)
+        self.__mt.bind()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.__mt.unbind()

--- a/src/mkernel/renderers/shaders/pnts/pntTgl_frgm_shdr.glsl
+++ b/src/mkernel/renderers/shaders/pnts/pntTgl_frgm_shdr.glsl
@@ -7,6 +7,7 @@ in gsOut {
 
 layout (location=0) out vec4 fclr;
 layout (location=1) out vec4 cid;
+//layout (location=2) out vec4 cid;
 
 void main() {
     fclr = gs_in.clr;

--- a/src/wkernel/devices/render/cameras/parts.py
+++ b/src/wkernel/devices/render/cameras/parts.py
@@ -183,6 +183,13 @@ class CameraBody:
         l, r, b, t = (self.__dim[k] for k in 'lrbt')
         return (r - l) / (t - b)
 
+    @property
+    def near(self):
+        return self.__dim['n']
+
+    @property
+    def far(self):
+        return self.__dim['f']
 
     @property
     def dim(self):
@@ -203,4 +210,9 @@ class CameraBody:
 
     @property
     def fshape(self):
+        """
+        frustum shape either 'o'(orthogonal) or 'p'(perspective)
+
+        :return:
+        """
         return self.__fshape

--- a/src/wkernel/devices/render/frame/base.py
+++ b/src/wkernel/devices/render/frame/base.py
@@ -16,6 +16,7 @@ import gkernel.color as clr
 
 from wkernel.devices.render._base import RenderDevice, RenderDeviceManager
 from global_tools.lazy import lazyProp
+from ckernel.render_context.opengl_context.constant_enum import DrawBufferFormats
 
 
 class FrameFactory:
@@ -62,6 +63,7 @@ class FrameFactory:
     def __init__(self, manager):
         self.__manager = wr.ref(manager)
         self.__size = None
+        self.__tids = set()
         self.__textures_prop = []
         self.__render_buffer_prop = []
 
@@ -77,17 +79,55 @@ class FrameFactory:
             raise TypeError
         self.__size = width, height
 
-    def append_texture(self, target, format, attachment_loc=None):
+    def append_color_texture(self, target, format, loc):
         """
-        append texture
+        append texture for color attachment
+
+        ! texture will be treated with attachment index of given order
+        :param target: target e.g. TEXTURE.TARGET.TWO_D
+        :param format: internal format
+        :param loc: int, color attachment id
+        :return:
+        """
+        # guess texture id if not given
+        if format not in DrawBufferFormats.COLOR:
+            raise TypeError
+        if not isinstance(loc, int):
+            raise TypeError
+
+        # check uniqueness
+        if loc in self.__tids:
+            raise ValueError
+
+        # append
+        self.__textures_prop.append((target, format, loc))
+        self.__tids.add(loc)
+        return self
+
+    def append_depth_texture(self, target, format):
+        """
+        append texture for depth
 
         ! texture will be treated with attachment index of given order
         :param target: target e.g. TEXTURE.TARGET.TWO_D
         :param format: internal format
         :return:
         """
-        self.__textures_prop.append((target, format, attachment_loc))
+        if format not in DrawBufferFormats.DEPTH:
+            raise TypeError
+
+        # check uniqueness
+        tid = 'd'
+        if tid in self.__tids:
+            raise ValueError
+
+        # append
+        self.__textures_prop.append((target, format, tid))
+        self.__tids.add(tid)
         return self
+
+    def append_depthstencil_texture(self, target, format):
+        raise NotImplementedError
 
     def set_render_buffer(self, format, attachment_loc=None):
         """
@@ -126,7 +166,7 @@ class FrameFactory:
             locs.append(i)
             render_bffrs.append(meta.MetaRenderBffr(iformat=f, width=w, height=h))
 
-        frame_bffr = meta.MetaFrameBffr(*textures, *render_bffrs, locs=locs)
+        frame_bffr = meta.MetaFrameBffr(*textures, *render_bffrs, tids=locs)
 
         manager = self.__manager()
         frame = Frame(manager, frame_bffr, w, h)
@@ -139,23 +179,29 @@ class FrameRenderer:
     __THIS_PATH = os.path.dirname(__file__)
     __quad_prgrm = meta.MetaPrgrm(vrtx_path=os.path.join(__THIS_PATH, 'quad_vrtx_shdr.glsl'),
                                   frgm_path=os.path.join(__THIS_PATH, 'quad_frgm_shdr.glsl'))
-
     __pane_prgrm = meta.MetaPrgrm(vrtx_path=os.path.join(__THIS_PATH, 'pane_vrtx_shdr.glsl'),
                                   frgm_path=os.path.join(__THIS_PATH, 'pane_frgm_shdr.glsl'))
+    __pane_depth_prgrm = meta.MetaPrgrm(vrtx_path=os.path.join(__THIS_PATH, 'pane_vrtx_shdr.glsl'),
+                                        frgm_path=os.path.join(__THIS_PATH, 'pane_depth_frgm_shdr.glsl'))
 
     def __init__(self):
         # quad set
         self.__quad_vbo = self.__quad_prgrm.vrtxattr_schema.create_vrtx_bffr()
-        self.__quad_vrtx_block = self.__quad_vbo.cache.request_block(size=4)
-        self.__quad_vrtx_block['tex_coord'] = (0, 0), (1, 0), (1, 1), (0, 1)
+        self.__quad_block = self.__quad_vbo.cache.request_block(size=4)
+        self.__quad_block['tex_coord'] = (0, 0), (1, 0), (1, 1), (0, 1)
         self.__quad_vao = meta.MetaVrtxArry(self.__quad_vbo)
         # pane set
         self.__pane_vbo = self.__pane_prgrm.vrtxattr_schema.create_vrtx_bffr()
-        self.__pane_vrtx_block = self.__pane_vbo.cache.request_block(size=4)
-        self.__pane_vrtx_block['tex_coord'] = (0, 0), (1, 0), (1, 1), (0, 1)
+        self.__pane_block = self.__pane_vbo.cache.request_block(size=4)
+        self.__pane_block['tex_coord'] = (0, 0), (1, 0), (1, 1), (0, 1)
         self.__pane_vao = meta.MetaVrtxArry(self.__pane_vbo)
+        # pane depth set
+        self.__pane_depth_vbo = self.__pane_depth_prgrm.vrtxattr_schema.create_vrtx_bffr()
+        self.__pane_depth_block = self.__pane_depth_vbo.cache.request_block(size=4)
+        self.__pane_depth_block['tex_coord'] = (0, 0), (1, 0), (1, 1), (0, 1)
+        self.__pane_depth_vao = meta.MetaVrtxArry(self.__pane_depth_vbo)
 
-    def render_pane_space(self, texture, pdomain_x, pdomain_y, pane_z, tdomain_x, tdomain_y):
+    def render_pane_space(self, texture, txtr_domain, pane_domain, pane_z):
         """
         render frame's given attachment on pane space
 
@@ -168,22 +214,40 @@ class FrameRenderer:
         :return:
         """
         # update
-        (xs, xe), (ys, ye) = pdomain_x, pdomain_y
-        self.__pane_vrtx_block['coord'] = (xs, ys, pane_z), (xe, ys, pane_z), (xe, ye, pane_z), (xs, ye, pane_z)
-        (xs, xe), (ys, ye) = tdomain_x, tdomain_y
-        self.__pane_vrtx_block['tex_coord'] = (xs, ys), (xe, ys), (xe, ye), (xs, ye)
+        xs, xe, ys, ye = txtr_domain
+        self.__pane_block['tex_coord'] = (xs, ys), (xe, ys), (xe, ye), (xs, ye)
+        xs, xe, ys, ye = pane_domain
+        self.__pane_block['coord'] = (xs, ys, pane_z), (xe, ys, pane_z), (xe, ye, pane_z), (xs, ye, pane_z)
         self.__pane_vbo.push_cache()
         # render
-        with texture as t:
-            with self.__pane_vao as vao:
+        with texture:
+            with self.__pane_vao:
                 with self.__pane_prgrm:
+                    gl.glDrawArrays(gl.GL_QUADS, 0, 4)
+
+    def render_pane_space_depth(self, color_txtr, depth_txtr, txtr_domain, pane_domain):
+        # update
+        xs, xe, ys, ye = txtr_domain
+        self.__pane_depth_block['tex_coord'] = (xs, ys), (xe, ys), (xe, ye), (xs, ye)
+        xs, xe, ys, ye = pane_domain
+        self.__pane_depth_block['coord'] = (xs, ys, 0), (xe, ys, 0), (xe, ye, 0), (xs, ye, 0)
+        self.__pane_depth_vbo.push_cache()
+
+        with color_txtr.as_unit(0), depth_txtr.as_unit(1):  # using texture as unit 0, 1
+            with self.__pane_depth_vao:
+                with self.__pane_depth_prgrm:
+                    # update uniforms
+                    self.__pane_depth_prgrm.uniforms['myTexture'] = 0
+                    self.__pane_depth_prgrm.uniforms['myDepth'] = 1
+                    self.__pane_depth_prgrm.push_uniforms()
+
                     gl.glDrawArrays(gl.GL_QUADS, 0, 4)
 
     def render_world_space(self, texture, quad_pos, domain_x, domain_y):
         # update vrtx attributes
         (xs, xe), (ys, ye) = domain_x, domain_y
-        self.__quad_vrtx_block['tex_coord'] = (xs, ys), (xe, ys), (xe, ye), (xs, ye)
-        self.__quad_vrtx_block['coord'] = quad_pos
+        self.__quad_block['tex_coord'] = (xs, ys), (xe, ys), (xe, ye), (xs, ye)
+        self.__quad_block['coord'] = quad_pos
         self.__quad_vbo.push_cache()
         # render
         with texture:
@@ -241,21 +305,38 @@ class Frame(RenderDevice):
         """
         return self.__size
 
-    def render_pane_space(self, aid, pdomain_x=(-1, 1), pdomain_y=(-1, 1), pane_z=0, tdomain_x=(0, 1),
-                          tdomain_y=(0, 1)):
+    def render_pane_space(self, tid, txtr_domain=(0, 1, 0, 1), pane_domain=(-1, 1, -1, 1), pane_z=0):
         """
         render frame's given attachment on pane space
 
-        :param aid:
-        :param pdomain_x: (-1.~1., -1.~1.), pane space x domain
-        :param pdomain_y: (-1.~1., -1.~1.), pane space y domain
+        :param tid: texture id, e.g.
+                    0, 1 - integers for color attachment
+                    'd' - depth attachment
+                    'ds' - depth stencil attachment
+        :param txtr_domain: (f, f, f, f), texture space x0,y0, x0,y0 domain
+        :param pane_domain: (-1.~1., -1.~1., -1.~1., -1.~1.), texture space x0,y0, x1,y1 domain
         :param pane_z: -1.~1., pane space z value, -1 closest
-        :param tdomain_x: (float, float), texture space x domain
-        :param tdomain_y: (float, float), texture space y domain
+        :param with_depth: bool, render with current frame buffer's depth texture
         :return:
         """
-        texture = self.__frame_bffr.get_texture_attachment(aid)
-        self.__renderer.render_pane_space(texture, pdomain_x, pdomain_y, pane_z, tdomain_x, tdomain_y)
+        texture = self.__frame_bffr.get_texture_attachment(tid)
+        self.__renderer.render_pane_space(texture, txtr_domain, pane_domain, pane_z)
+
+    def render_pane_space_depth(self, tid, txtr_domain=(0, 1, 0, 1), pane_domain=(-1, 1, -1, 1)):
+        """
+        render frame's given attachment on pane space with depth texture
+
+        :param tid: texture id, e.g.
+                    0, 1 - integers for color attachment
+                    'd' - depth attachment
+                    'ds' - depth stencil attachment
+        :param txtr_domain: (f, f, f, f), texture space x0,y0, x0,y0 domain
+        :param pane_domain: (-1.~1., -1.~1., -1.~1., -1.~1.), texture space x0,y0, x1,y1 domain
+        :return:
+        """
+        color_txtr = self.__frame_bffr.get_texture_attachment(tid)
+        depth_txtr = self.__frame_bffr.get_texture_attachment('d')
+        self.__renderer.render_pane_space_depth(color_txtr, depth_txtr, txtr_domain, pane_domain)
 
     def render_world_space(self, aid, pln: gt.Pln, width, height, tdomain_x=(0, 1), tdomain_y=(0, 1)):
         """
@@ -287,18 +368,18 @@ class Frame(RenderDevice):
         texture = self.__frame_bffr.get_texture_attachment(aid)
         self.__renderer.render_world_space(texture, quad_pos, tdomain_x, tdomain_y)
 
-    def pick_texture(self, aid, pos, parameterized):
+    def pick_texture(self, tid, pos, parameterized):
         """
         pick texture color of given attachment id, position
 
-        :param aid: int, color attachment id
+        :param tid: int, color attachment id
         :param pos: (Number, Number), pixel coordinate
         :param parameterized: bool, if given pixel coordinate is of parameterized(0 ~ 1.0)
         :return:
         """
-        texture = self.frame_bffr.get_texture_attachment(aid)
+        texture = self.frame_bffr.get_texture_attachment(tid)
         if parameterized:
-            x, y = [int(a*b) for a, b in zip(pos, texture.size)]
+            x, y = [int(a * b) for a, b in zip(pos, texture.size)]
         else:
             x, y = pos
         gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT1)

--- a/src/wkernel/devices/render/frame/pane_depth_frgm_shdr.glsl
+++ b/src/wkernel/devices/render/frame/pane_depth_frgm_shdr.glsl
@@ -3,9 +3,11 @@
 out vec4 fColor;
 
 layout (location=0) uniform sampler2D myTexture;
+layout (location=1) uniform sampler2D myDepth;
 
 in vec2 texCoord;
 
 void main() {
     fColor = texture(myTexture, texCoord);
+    gl_FragDepth = texture(myDepth, texCoord).x;
 }

--- a/src/wkernel/devices/render/frame/quad_frgm_shdr.glsl
+++ b/src/wkernel/devices/render/frame/quad_frgm_shdr.glsl
@@ -2,7 +2,7 @@
 
 out vec4 fColor;
 
-uniform sampler2D myTexture;
+layout (location=0) uniform sampler2D myTexture;
 
 in vec2 texCoord;
 


### PR DESCRIPTION
implement `Ground`
    Simple shader driven ground rendering. Much to learn, play with shaders.

implement frame depth rendering
    `Frame().render_pane_space_depth`, separated instead of using optional argument with `render_pane_space`, as ~depth doesn't require explicit depth value argument.

implement `MetaTexture().as_unit`
    To explicitly state texture unit for gl.glActiveTexture with context manager pattern.